### PR TITLE
Handle corrupted localStorage in useGameData

### DIFF
--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -61,7 +61,15 @@ const createInitialUser = (username: string): User => ({
 export const useGameData = () => {
   const [gameState, setGameState] = useState<GameState>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
-    return stored ? JSON.parse(stored) : {
+    if (stored) {
+      try {
+        return JSON.parse(stored);
+      } catch (error) {
+        console.warn('Failed to parse game data from localStorage', error);
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    }
+    return {
       user: null,
       worm: null,
       trainings: defaultTrainings,


### PR DESCRIPTION
## Summary
- Avoid crashing when stored game state JSON is invalid by wrapping parsing in try/catch
- Log a warning, clear bad localStorage data, and fall back to default state

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: several existing lint errors in unrelated files)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b50a682130832286a27c75e96955c3