### PR TITLE
Type dungeon difficulties in PveArena

### DIFF
--- a/src/components/PveArena.tsx
+++ b/src/components/PveArena.tsx
@@ -33,7 +33,14 @@ export const PveArena = ({ worm, onStartDungeon, onStartRaid, onStartAdventure }
     }
   };
 
-  const dungeonDifficulties = [
+  const dungeonDifficulties: {
+    id: 'easy' | 'medium' | 'hard' | 'elite';
+    nameHu: string;
+    description: string;
+    energyCost: number;
+    minLevel: number;
+    rewards: string;
+  }[] = [
     {
       id: 'easy',
       nameHu: 'Könnyű Börtön',
@@ -120,7 +127,7 @@ export const PveArena = ({ worm, onStartDungeon, onStartRaid, onStartAdventure }
                       </div>
                       <Button
                         size="sm"
-                        onClick={() => onStartDungeon(dungeon.id as any)}
+                        onClick={() => onStartDungeon(dungeon.id)}
                         disabled={!canAfford || !meetsLevel}
                       >
                         Indulás


### PR DESCRIPTION
## Summary
- Define `dungeonDifficulties` with strict `id` union type
- Remove unsafe `any` cast when starting a dungeon

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: found 8 errors, 8 warnings)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b50b121a108322a427f891b6d870e1