### PR TITLE
Enforce equipment subtype typing for random equipment

### DIFF
--- a/src/data/shopItems.ts
+++ b/src/data/shopItems.ts
@@ -165,7 +165,10 @@ export const equipmentTemplates = {
 };
 
 // Generate random equipment item
-export const generateRandomEquipment = (tier: 'low' | 'mid-bottom' | 'mid-top' | 'high-bottom' | 'high-middle' | 'high-top'): Item => {
+export const generateRandomEquipment = (
+  tier: 'low' | 'mid-bottom' | 'mid-top' | 'high-bottom' | 'high-middle' | 'high-top',
+  subType: 'helmet' | 'armor' | 'weapon' | 'accessory'
+): Item => {
   // Determine rarity based on tier
   let rarity: 'common' | 'rare' | 'epic' | 'legendary';
   let statMultiplier: number;
@@ -204,36 +207,28 @@ export const generateRandomEquipment = (tier: 'low' | 'mid-bottom' | 'mid-top' |
       break;
   }
 
-  // Choose equipment type
-  const equipmentTypes = ['helmet', 'armor', 'accessory', 'weapon'];
-  const equipmentType = equipmentTypes[Math.floor(Math.random() * equipmentTypes.length)];
-
+  // Choose template based on subtype
   let template: { nameHu: string; icon: string };
-  let subType: string;
 
-  switch (equipmentType) {
+  switch (subType) {
     case 'helmet':
       template = equipmentTemplates.helmets[Math.floor(Math.random() * equipmentTemplates.helmets.length)];
-      subType = 'helmet';
       break;
     case 'armor':
       template = equipmentTemplates.chestpieces[Math.floor(Math.random() * equipmentTemplates.chestpieces.length)];
-      subType = 'armor';
       break;
     case 'accessory':
       template = equipmentTemplates.gloves[Math.floor(Math.random() * equipmentTemplates.gloves.length)];
-      subType = 'accessory';
       break;
-    case 'weapon':
+    case 'weapon': {
       const weaponTypes = Object.keys(equipmentTemplates.weapons);
       const weaponType = weaponTypes[Math.floor(Math.random() * weaponTypes.length)];
-      const weaponArray = equipmentTemplates.weapons[weaponType as keyof typeof equipmentTemplates.weapons];
+      const weaponArray = equipmentTemplates.weapons[
+        weaponType as keyof typeof equipmentTemplates.weapons
+      ];
       template = weaponArray[Math.floor(Math.random() * weaponArray.length)];
-      subType = 'weapon';
       break;
-    default:
-      template = equipmentTemplates.helmets[0];
-      subType = 'helmet';
+    }
   }
 
   // Generate random stats
@@ -263,7 +258,7 @@ export const generateRandomEquipment = (tier: 'low' | 'mid-bottom' | 'mid-top' |
     description: `A ${rarity} piece of equipment found during exploration.`,
     descriptionHu: `Egy ${rarity === 'common' ? 'közönséges' : rarity === 'rare' ? 'ritka' : rarity === 'epic' ? 'epikus' : 'legendás'} felszerelés, amit felfedezés során találtak.`,
     type: 'equipment',
-    subType: subType as any,
+    subType,
     price: Math.floor(level * 50 * (rarity === 'common' ? 1 : rarity === 'rare' ? 2 : rarity === 'epic' ? 4 : 8)),
     rarity,
     icon: template.icon,

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -58,6 +58,10 @@ const createInitialUser = (username: string): User => ({
   createdAt: Date.now()
 });
 
+const randomEquipmentSubType = () => (
+  ['helmet', 'armor', 'weapon', 'accessory'] as const
+)[Math.floor(Math.random() * 4)];
+
 export const useGameData = () => {
   const [gameState, setGameState] = useState<GameState>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
@@ -603,7 +607,7 @@ export const useGameData = () => {
 
   // Get total stats including equipment bonuses
   const getTotalStats = (worm: Worm) => {
-    let totalStats = {
+    const totalStats = {
       strength: worm.strength,
       dexterity: worm.dexterity,
       endurance: worm.endurance,
@@ -699,7 +703,7 @@ export const useGameData = () => {
                         tour.tier === 'high-middle' ? 0.7 : 0.8;
 
       if (Math.random() < dropChance) {
-        rewardItem = generateRandomEquipment(tour.tier);
+        rewardItem = generateRandomEquipment(tour.tier, randomEquipmentSubType());
       }
 
       const updatedInventory = rewardItem 
@@ -774,7 +778,7 @@ export const useGameData = () => {
                         difficulty === 'hard' ? 0.75 : 0.9;
 
       if (Math.random() < dropChance) {
-        rewardItem = generateRandomEquipment(dungeon.tier);
+        rewardItem = generateRandomEquipment(dungeon.tier, randomEquipmentSubType());
       }
 
       const updatedWorm = {
@@ -841,11 +845,11 @@ export const useGameData = () => {
 
       // Always drop equipment from raids, chance for multiple items
       const rewards: Item[] = [];
-      rewards.push(generateRandomEquipment('high-middle')); // Guaranteed high-tier item
+      rewards.push(generateRandomEquipment('high-middle', randomEquipmentSubType())); // Guaranteed high-tier item
       
       // 50% chance for second item
       if (Math.random() < 0.5) {
-        rewards.push(generateRandomEquipment('high-bottom'));
+        rewards.push(generateRandomEquipment('high-bottom', randomEquipmentSubType()));
       }
 
       const updatedWorm = {
@@ -912,7 +916,7 @@ export const useGameData = () => {
       // 70% chance for equipment
       let rewardItem: Item | null = null;
       if (Math.random() < 0.7) {
-        rewardItem = generateRandomEquipment('mid-top');
+        rewardItem = generateRandomEquipment('mid-top', randomEquipmentSubType());
       }
 
       const updatedWorm = {


### PR DESCRIPTION
## Summary
- require specific equipment subtypes when generating random gear
- remove unsafe subtype cast and add helper for random subtype selection

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: 12 problems (4 errors, 8 warnings))
- `npx eslint src/data/shopItems.ts src/hooks/useGameData.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b50c3bce7883229fbc0d69e0863db6