### PR TITLE
Use Link for home navigation on NotFound page

### DIFF
--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -1,4 +1,4 @@
-import { useLocation } from "react-router-dom";
+import { Link, useLocation } from "react-router-dom";
 import { useEffect } from "react";
 
 const NotFound = () => {
@@ -16,9 +16,9 @@ const NotFound = () => {
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4">404</h1>
         <p className="text-xl text-gray-600 mb-4">Oops! Page not found</p>
-        <a href="/" className="text-blue-500 hover:text-blue-700 underline">
+        <Link to="/" className="text-blue-500 hover:text-blue-700 underline">
           Return to Home
-        </a>
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- replace anchor tag with react-router Link on the 404 page for client-side navigation

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint` (fails: An interface declaring no members is equivalent to its supertype @typescript-eslint/no-empty-object-type; A `require()` style import is forbidden @typescript-eslint/no-require-imports)


------
https://chatgpt.com/codex/tasks/task_e_68b50d5adc6c8322ae758f33f6dbf769