### PR TITLE
Fix undefined tours causing explore page crash

### DIFF
--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -62,32 +62,35 @@ const randomEquipmentSubType = () => (
   ['helmet', 'armor', 'weapon', 'accessory'] as const
 )[Math.floor(Math.random() * 4)];
 
+const defaultGameState: GameState = {
+  user: null,
+  worm: null,
+  trainings: defaultTrainings,
+  jobs: defaultJobs,
+  jobAssignments: [],
+  dailyJobsCompleted: 0,
+  inventory: [],
+  shopItems: defaultShopItems,
+  tourResults: defaultTours,
+  battles: [],
+  abilities: defaultAbilities,
+  players: [],
+  leaderboard: []
+};
+
 export const useGameData = () => {
   const [gameState, setGameState] = useState<GameState>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       try {
-        return JSON.parse(stored);
+        const parsed = JSON.parse(stored);
+        return { ...defaultGameState, ...parsed };
       } catch (error) {
         console.warn('Failed to parse game data from localStorage', error);
         localStorage.removeItem(STORAGE_KEY);
       }
     }
-    return {
-      user: null,
-      worm: null,
-      trainings: defaultTrainings,
-      jobs: defaultJobs,
-      jobAssignments: [],
-      dailyJobsCompleted: 0,
-      inventory: [],
-      shopItems: defaultShopItems,
-      tourResults: defaultTours,
-      battles: [],
-      abilities: defaultAbilities,
-      players: [],
-      leaderboard: []
-    };
+    return defaultGameState;
   });
 
   const { toast } = useToast();

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -118,8 +118,8 @@ const Index = () => {
       
       case 'tours':
         return (
-          <TourRoom 
-            tours={tourResults}
+          <TourRoom
+            tours={tourResults ?? []}
             worm={worm}
             onStartTour={startTour}
             isTourAvailable={isTourAvailable}


### PR DESCRIPTION
## Summary
- ensure stored game state merges with defaults to include tours
- guard TourRoom with fallback so explore page always receives an array

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: existing lint errors in unrelated files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b50fc6d3f883228a0d782f31de7312