### PR TITLE
feat: add simple local auth system

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,0 +1,87 @@
+import http from 'http';
+import fs from 'fs';
+import path from 'path';
+import crypto from 'crypto';
+
+const USERS_DIR = path.join(process.cwd(), 'users');
+const DATA_FILE = path.join(USERS_DIR, 'users.json');
+
+if (!fs.existsSync(USERS_DIR)) {
+  fs.mkdirSync(USERS_DIR);
+}
+if (!fs.existsSync(DATA_FILE)) {
+  fs.writeFileSync(DATA_FILE, '[]', 'utf-8');
+}
+
+const readUsers = () => {
+  const raw = fs.readFileSync(DATA_FILE, 'utf-8');
+  return JSON.parse(raw);
+};
+
+const writeUsers = (users) => {
+  fs.writeFileSync(DATA_FILE, JSON.stringify(users, null, 2));
+};
+
+const hashPassword = (password) =>
+  crypto.createHash('sha256').update(password).digest('hex');
+
+const collectBody = (req, cb) => {
+  let body = '';
+  req.on('data', (chunk) => {
+    body += chunk;
+  });
+  req.on('end', () => cb(body));
+};
+
+const server = http.createServer((req, res) => {
+  if (req.method === 'POST' && req.url === '/api/register') {
+    collectBody(req, (body) => {
+      try {
+        const { username, password, data } = JSON.parse(body);
+        const users = readUsers();
+        if (users.find((u) => u.username === username)) {
+          res.writeHead(400, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ message: 'User exists' }));
+          return;
+        }
+        const passwordHash = hashPassword(password);
+        users.push({ username, passwordHash, data });
+        writeUsers(users);
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok' }));
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: 'Invalid body' }));
+      }
+    });
+  } else if (req.method === 'POST' && req.url === '/api/login') {
+    collectBody(req, (body) => {
+      try {
+        const { username, password } = JSON.parse(body);
+        const users = readUsers();
+        const user = users.find(
+          (u) => u.username === username && u.passwordHash === hashPassword(password)
+        );
+        if (!user) {
+          res.writeHead(401, { 'Content-Type': 'application/json' });
+          res.end(JSON.stringify({ message: 'Invalid credentials' }));
+          return;
+        }
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(user.data));
+      } catch {
+        res.writeHead(400, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify({ message: 'Invalid body' }));
+      }
+    });
+  } else {
+    res.writeHead(404);
+    res.end();
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Auth server running on http://localhost:${PORT}`);
+});
+

--- a/src/components/LoginForm.tsx
+++ b/src/components/LoginForm.tsx
@@ -1,0 +1,78 @@
+import { useState } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface LoginFormProps {
+  onLogin: (username: string, password: string) => void;
+  onSwitchToRegister: () => void;
+}
+
+export const LoginForm = ({ onLogin, onSwitchToRegister }: LoginFormProps) => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    onLogin(username, password);
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center p-4 bg-gradient-to-br from-background via-card to-secondary">
+      <Card className="w-full max-w-md bg-gradient-soil/10 border-primary/30 shadow-2xl">
+        <CardHeader className="text-center space-y-4">
+          <div className="text-6xl animate-bounce-gentle">🪱</div>
+          <CardTitle className="text-3xl font-bold text-primary">
+            Kukac Nevelde
+          </CardTitle>
+        </CardHeader>
+
+        <CardContent className="space-y-4">
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="username">Felhasználónév</Label>
+              <Input
+                id="username"
+                type="text"
+                value={username}
+                onChange={(e) => setUsername(e.target.value)}
+                className="transition-smooth"
+              />
+            </div>
+
+            <div className="space-y-2">
+              <Label htmlFor="password">Jelszó</Label>
+              <Input
+                id="password"
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="transition-smooth"
+              />
+            </div>
+
+            <Button
+              type="submit"
+              className="w-full text-lg py-6 transition-bounce bg-gradient-worm hover:shadow-worm"
+              disabled={!username.trim() || !password.trim()}
+            >
+              Bejelentkezés
+            </Button>
+          </form>
+
+          <div className="text-center text-sm">
+            <button
+              onClick={onSwitchToRegister}
+              className="text-primary underline"
+            >
+              Nincs még fiókod? Regisztrálj
+            </button>
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  );
+};
+
+export default LoginForm;

--- a/src/components/SetupForm.tsx
+++ b/src/components/SetupForm.tsx
@@ -7,25 +7,32 @@ import { PlayerClass } from '../types/game';
 import { ClassSelector } from './ClassSelector';
 
 interface SetupFormProps {
-  onCreateWorm: (username: string, wormName: string, playerClass: PlayerClass) => void;
+  onRegister: (
+    username: string,
+    password: string,
+    wormName: string,
+    playerClass: PlayerClass
+  ) => void;
+  onSwitchToLogin: () => void;
 }
 
-export const SetupForm = ({ onCreateWorm }: SetupFormProps) => {
+export const SetupForm = ({ onRegister, onSwitchToLogin }: SetupFormProps) => {
   const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
   const [wormName, setWormName] = useState('');
   const [selectedClass, setSelectedClass] = useState<PlayerClass | null>(null);
   const [step, setStep] = useState<'profile' | 'class'>('profile');
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    if (username.trim() && wormName.trim()) {
+    if (username.trim() && password.trim() && wormName.trim()) {
       setStep('class');
     }
   };
 
   const handleClassConfirm = () => {
     if (selectedClass) {
-      onCreateWorm(username.trim(), wormName.trim(), selectedClass);
+      onRegister(username.trim(), password.trim(), wormName.trim(), selectedClass);
     }
   };
 
@@ -61,6 +68,18 @@ export const SetupForm = ({ onCreateWorm }: SetupFormProps) => {
                     className="transition-smooth"
                   />
                 </div>
+
+                <div className="space-y-2">
+                  <Label htmlFor="password">Jelszó</Label>
+                  <Input
+                    id="password"
+                    type="password"
+                    placeholder="Adj meg egy jelszót..."
+                    value={password}
+                    onChange={(e) => setPassword(e.target.value)}
+                    className="transition-smooth"
+                  />
+                </div>
                 
                 <div className="space-y-2">
                   <Label htmlFor="wormName">Kukac neve</Label>
@@ -89,25 +108,31 @@ export const SetupForm = ({ onCreateWorm }: SetupFormProps) => {
                   </div>
                 </div>
                 
-                <Button 
-                  type="submit" 
+                <Button
+                  type="submit"
                   className="w-full text-lg py-6 transition-bounce bg-gradient-worm hover:shadow-worm"
-                  disabled={!username.trim() || !wormName.trim()}
+                  disabled={!username.trim() || !password.trim() || !wormName.trim()}
                 >
                   🎉 Következő: Osztály Választás
                 </Button>
               </form>
-              
+
               <div className="text-center text-sm text-muted-foreground">
                 <p>
                   🎮 Növeld a kukacod statjait tréninggel<br/>
                   💼 Végezz munkákat érmékért<br/>
                   🏆 Versenyzz a ranglistán
                 </p>
+                <button
+                  onClick={onSwitchToLogin}
+                  className="text-primary underline mt-2"
+                >
+                  Már van fiókod? Bejelentkezés
+                </button>
               </div>
             </>
           ) : (
-            <ClassSelector 
+            <ClassSelector
               selectedClass={selectedClass}
               onSelectClass={setSelectedClass}
               onConfirm={handleClassConfirm}

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps;
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -5,6 +5,7 @@ import { Dashboard } from '../components/Dashboard';
 import { TrainingRoom } from '../components/TrainingRoom';
 import { JobBoard } from '../components/JobBoard';
 import { SetupForm } from '../components/SetupForm';
+import { LoginForm } from '../components/LoginForm';
 import { ProfileEditor } from '../components/ProfileEditor';
 import { Shop } from '../components/Shop';
 import { Inventory } from '../components/Inventory';
@@ -16,9 +17,11 @@ type Page = 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory'
 
 const Index = () => {
   const [currentPage, setCurrentPage] = useState<Page>('dashboard');
+  const [authMode, setAuthMode] = useState<'login' | 'register'>('login');
   const {
     gameState,
-    createUserAndWorm,
+    registerUser,
+    loginUser,
     executeTrain,
     acceptJob,
     completeJob,
@@ -39,15 +42,25 @@ const Index = () => {
     isLoggedIn
   } = useGameData();
 
-  // If no user/worm exists, show setup form
+  // If no user/worm exists, show auth forms
   if (!isLoggedIn) {
-    return <SetupForm onCreateWorm={createUserAndWorm} />;
+    return authMode === 'login' ? (
+      <LoginForm
+        onLogin={loginUser}
+        onSwitchToRegister={() => setAuthMode('register')}
+      />
+    ) : (
+      <SetupForm
+        onRegister={registerUser}
+        onSwitchToLogin={() => setAuthMode('login')}
+      />
+    );
   }
 
   const { user, worm, trainings, jobs, jobAssignments, inventory, shopItems, tourResults, battles, players, abilities } = gameState;
   
   if (!worm) {
-    return <SetupForm onCreateWorm={createUserAndWorm} />;
+    return null;
   }
 
   const renderPage = () => {

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -142,5 +143,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- add minimal Node server for login/register storing hashed user data in local JSON
- create login and registration forms with password support
- wire up auth workflow and server communication
- fix lint errors in existing UI components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b5123742d083228be42d9d650ff84a