### PR TITLE
Enable LAN access and dynamic API URL

### DIFF
--- a/server.js
+++ b/server.js
@@ -34,6 +34,15 @@ const collectBody = (req, cb) => {
 };
 
 const server = http.createServer((req, res) => {
+  res.setHeader('Access-Control-Allow-Origin', '*');
+  res.setHeader('Access-Control-Allow-Methods', 'GET,POST,OPTIONS');
+  res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
+  if (req.method === 'OPTIONS') {
+    res.writeHead(204);
+    res.end();
+    return;
+  }
+
   if (req.method === 'POST' && req.url === '/api/register') {
     collectBody(req, (body) => {
       try {
@@ -81,7 +90,7 @@ const server = http.createServer((req, res) => {
 });
 
 const PORT = process.env.PORT || 3001;
-server.listen(PORT, () => {
+server.listen(PORT, '0.0.0.0', () => {
   console.log(`Auth server running on http://localhost:${PORT}`);
 });
 

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -9,7 +9,8 @@ import { useToast } from './use-toast';
 import defaultWormImage from '../assets/default-worm.png';
 
 const STORAGE_KEY = 'worm-daycare-data';
-const API_URL = 'http://localhost:3001';
+const host = window.location.hostname;
+const API_URL = `http://${host}:3001`;
 
 // Generate random worm stats for new worms
 const generateRandomStats = () => ({


### PR DESCRIPTION
## Summary
- Serve API on all interfaces and add CORS headers
- Use frontend hostname to build API URL for fetch calls

## Testing
- ⚠️ `npm test` (missing script)
- ✅ `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5172bb57c83229465a8e56f19c0fd