### PR TITLE
Use relative API URL for frontend requests

### DIFF
--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -9,8 +9,7 @@ import { useToast } from './use-toast';
 import defaultWormImage from '../assets/default-worm.png';
 
 const STORAGE_KEY = 'worm-daycare-data';
-const host = window.location.hostname;
-const API_URL = `http://${host}:3001`;
+const API_URL = '';
 
 // Generate random worm stats for new worms
 const generateRandomStats = () => ({


### PR DESCRIPTION
## Summary
- use relative API_URL so frontend calls `/api/...`

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b51ae17ec083228e361d01755e06ca