### PR TITLE
feat: allow configurable API URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,11 @@ This project is built with:
 - preview: `bun run preview`
 Alternatív: ha `npm`/`pnpm` jobban kézre áll, használd a package.json scriptjeit (pl. `npm run dev`).
 
+### API szerver
+
+A kliens a `VITE_API_URL` környezeti változóval konfigurálható hitelesítési API
+címet vár. Alapértelmezetten a `http://localhost:3001` címre küld kéréseket.
+
 ## 3) Struktúra (kivonat)
 
 ```

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -9,7 +9,8 @@ import { useToast } from './use-toast';
 import defaultWormImage from '../assets/default-worm.png';
 
 const STORAGE_KEY = 'worm-daycare-data';
-const API_URL = '';
+// Base URL of the authentication API. Can be overridden with VITE_API_URL.
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:3001';
 
 // Generate random worm stats for new worms
 const generateRandomStats = () => ({


### PR DESCRIPTION
## Summary
- allow configuring authentication server via `VITE_API_URL` with default `http://localhost:3001`
- document backend URL setup in README

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5208a78c88322bc1f586b8f8aa8cd