### PR TITLE
Use API helper for registration with JSON and error handling

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+VITE_API_BASE=

--- a/README.md
+++ b/README.md
@@ -38,8 +38,8 @@ Alternatív: ha `npm`/`pnpm` jobban kézre áll, használd a package.json script
 
 ### API szerver
 
-A kliens a `VITE_API_URL` környezeti változóval konfigurálható hitelesítési API
-címet vár. Alapértelmezetten a `http://localhost:3001` címre küld kéréseket.
+A kliens a `VITE_API_BASE` környezeti változóval konfigurálható hitelesítési API
+címet vár. Alapértelmezetten ugyanazon originre küld kéréseket, azaz `/api/...` útvonalra.
 ## 3) Struktúra (kivonat)
 
 ```

--- a/src/components/ClassSelector.tsx
+++ b/src/components/ClassSelector.tsx
@@ -8,6 +8,7 @@ interface ClassSelectorProps {
   selectedClass: PlayerClass | null;
   onSelectClass: (playerClass: PlayerClass) => void;
   onConfirm: () => void;
+  loading?: boolean;
 }
 
 const classInfo: Record<PlayerClass, {
@@ -84,7 +85,7 @@ const classInfo: Record<PlayerClass, {
   }
 };
 
-export const ClassSelector = ({ selectedClass, onSelectClass, onConfirm }: ClassSelectorProps) => {
+export const ClassSelector = ({ selectedClass, onSelectClass, onConfirm, loading }: ClassSelectorProps) => {
   return (
     <div className="space-y-6">
       <div className="text-center">
@@ -144,8 +145,10 @@ export const ClassSelector = ({ selectedClass, onSelectClass, onConfirm }: Class
 
       {selectedClass && (
         <div className="text-center">
-          <Button onClick={onConfirm} size="lg" className="px-8">
-            {classInfo[selectedClass].icon} {classInfo[selectedClass].nameHu} Választása
+          <Button onClick={onConfirm} size="lg" className="px-8" disabled={loading}>
+            {loading
+              ? 'Regisztrálás...'
+              : `${classInfo[selectedClass].icon} ${classInfo[selectedClass].nameHu} Választása`}
           </Button>
         </div>
       )}

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,27 @@
+export const API_BASE = import.meta?.env?.VITE_API_BASE?.replace(/\/+$/, "") || "";
+
+export async function apiFetch<T = unknown>(path: string, init?: RequestInit): Promise<T> {
+  const url = `${API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
+  const res = await fetch(url, {
+    // do not set mode: 'no-cors'
+    ...init,
+    headers: {
+      "Content-Type": "application/json",
+      ...(init?.headers || {})
+    }
+  });
+
+  let data: any = null;
+  try {
+    // server returns JSON on both success and error
+    data = await res.json();
+  } catch {
+    // ignore parse error; keep data = null
+  }
+
+  if (!res.ok) {
+    const reason = (data && (data.error || data.message)) || res.statusText || "Request failed";
+    throw new Error(reason);
+  }
+  return data as T;
+}

--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -1,0 +1,30 @@
+import { apiFetch } from "@/lib/api";
+
+export interface RegisterBody {
+  username: string;
+  password: string;
+  data?: any;
+}
+
+export interface RegisterResponse {
+  status: string;
+}
+
+export async function registerUser(body: RegisterBody): Promise<RegisterResponse> {
+  return apiFetch<RegisterResponse>("/api/register", {
+    method: "POST",
+    body: JSON.stringify(body)
+  });
+}
+
+export interface LoginBody {
+  username: string;
+  password: string;
+}
+
+export async function loginUser<T = any>(body: LoginBody): Promise<T> {
+  return apiFetch<T>("/api/login", {
+    method: "POST",
+    body: JSON.stringify(body)
+  });
+}


### PR DESCRIPTION
## Summary
- add reusable `apiFetch` wrapper with configurable `VITE_API_BASE`
- route registration/login through `apiFetch` and surface server errors
- enhance registration form with validation and loading/error feedback

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b59c9b5eac83228d6bd24a07954e3d