### PR TITLE
Add logout option and clear cached game data

### DIFF
--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -5,9 +5,10 @@ interface NavigationProps {
   currentPage: 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory' | 'tours' | 'pvp' | 'pve';
   onNavigate: (page: 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory' | 'tours' | 'pvp' | 'pve') => void;
   coins: number;
+  onLogout: () => void;
 }
 
-export const Navigation = ({ currentPage, onNavigate, coins }: NavigationProps) => {
+export const Navigation = ({ currentPage, onNavigate, coins, onLogout }: NavigationProps) => {
   const navItems = [
     { id: 'dashboard', label: 'Vezérlőpult', icon: '🏠' },
     { id: 'training', label: 'Tréning', icon: '💪' },
@@ -50,6 +51,14 @@ export const Navigation = ({ currentPage, onNavigate, coins }: NavigationProps) 
                 <span className="hidden sm:inline">{item.label}</span>
               </Button>
             ))}
+            <Button
+              variant="outline"
+              onClick={onLogout}
+              className="flex items-center gap-2 transition-bounce"
+            >
+              <span className="text-lg">🚪</span>
+              <span className="hidden sm:inline">Kijelentkezés</span>
+            </Button>
           </div>
         </div>
       </div>

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -141,6 +141,9 @@ export const useGameData = () => {
     wormName: string,
     playerClass: PlayerClass
   ) => {
+    // Clear any previously cached game state to avoid leaking data between users
+    localStorage.removeItem(STORAGE_KEY);
+
     const user = createInitialUser(username);
     const worm = createInitialWorm(wormName, playerClass);
 
@@ -171,6 +174,9 @@ export const useGameData = () => {
 
   const loginUser = async (username: string, password: string) => {
     try {
+      // Ensure old cached data doesn't persist when switching accounts
+      localStorage.removeItem(STORAGE_KEY);
+
       const data = await apiLoginUser<GameState>({ username, password });
       setGameState({ ...defaultGameState, ...data });
     } catch (err) {
@@ -994,6 +1000,11 @@ export const useGameData = () => {
     return level;
   };
 
+  const logout = () => {
+    localStorage.removeItem(STORAGE_KEY);
+    setGameState(defaultGameState);
+  };
+
   return {
     gameState,
     registerUser,
@@ -1015,6 +1026,7 @@ export const useGameData = () => {
     startDungeon,
     startRaid,
     startAdventure,
-    isLoggedIn: !!gameState.user && !!gameState.worm
+    isLoggedIn: !!gameState.user && !!gameState.worm,
+    logout
   };
 };

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -39,7 +39,8 @@ const Index = () => {
     startDungeon,
     startRaid,
     startAdventure,
-    isLoggedIn
+    isLoggedIn,
+    logout
   } = useGameData();
 
   // If no user/worm exists, show auth forms
@@ -170,10 +171,11 @@ const Index = () => {
   return (
     <div className="min-h-screen bg-gradient-to-br from-background via-card to-secondary">
       <div className="container mx-auto p-4 space-y-6">
-        <Navigation 
+        <Navigation
           currentPage={currentPage}
           onNavigate={setCurrentPage}
           coins={worm.coins}
+          onLogout={logout}
         />
         
         <main className="pb-8">


### PR DESCRIPTION
## Summary
- clear local game state before registering or logging in
- add logout helper to reset state
- expose logout button in navigation bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68b6c0f7a8508322ab58aae7d41bafdc