### PR TITLE
feat: persist game state

### DIFF
--- a/src/services/auth.ts
+++ b/src/services/auth.ts
@@ -28,3 +28,16 @@ export async function loginUser<T = unknown>(body: LoginBody): Promise<T> {
     body: JSON.stringify(body)
   });
 }
+
+export interface SaveBody {
+  username: string;
+  password: string;
+  data: Record<string, unknown>;
+}
+
+export async function saveUser(body: SaveBody): Promise<RegisterResponse> {
+  return apiFetch<RegisterResponse>("/api/save", {
+    method: "POST",
+    body: JSON.stringify(body)
+  });
+}


### PR DESCRIPTION
## Summary
- add `/api/save` endpoint for storing user progress
- save game state automatically and on logout from the client

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6c58f79688322a6da8e698fd4b305