### PR TITLE
refactor: extract auth logic into separate hook

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,0 +1,42 @@
+import { useRef, useCallback } from 'react';
+import { registerUser as apiRegisterUser, loginUser as apiLoginUser, saveUser as apiSaveUser } from '@/services/auth';
+import type { GameState } from '../types/game';
+
+interface RegisterParams {
+  username: string;
+  password: string;
+  data: GameState;
+}
+
+export const useAuth = () => {
+  const credentialsRef = useRef<{ username: string; password: string } | null>(null);
+
+  const registerUser = useCallback(async ({ username, password, data }: RegisterParams) => {
+    await apiRegisterUser({ username, password, data });
+    credentialsRef.current = { username, password };
+  }, []);
+
+  const loginUser = useCallback(async (username: string, password: string): Promise<GameState> => {
+    const data = await apiLoginUser<GameState>({ username, password });
+    credentialsRef.current = { username, password };
+    return data;
+  }, []);
+
+  const saveGame = useCallback(async (state: GameState) => {
+    const creds = credentialsRef.current;
+    if (!creds) return;
+    try {
+      await apiSaveUser({ username: creds.username, password: creds.password, data: state });
+    } catch (err) {
+      console.error('Failed to save game state', err);
+    }
+  }, []);
+
+  const logout = useCallback(() => {
+    credentialsRef.current = null;
+  }, []);
+
+  return { registerUser, loginUser, saveGame, logout, credentialsRef };
+};
+
+export type UseAuthReturn = ReturnType<typeof useAuth>;


### PR DESCRIPTION
## Summary
- extract auth API calls into new `useAuth` hook
- refactor `useGameData` to delegate auth and saving responsibilities to `useAuth`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b6ddfe3c14832298431ee075ddc599