### PR TITLE
feat: add marketplace and item selling

### DIFF
--- a/src/components/Inventory.tsx
+++ b/src/components/Inventory.tsx
@@ -13,6 +13,8 @@ interface InventoryProps {
   onUseItem: (itemId: string) => void;
   onEquipItem: (itemId: string) => void;
   onUnequipItem: (slot: keyof Worm['equipment']) => void;
+  onListItem: (itemId: string, price: number) => void;
+  onSellToShop: (itemId: string) => void;
   getTotalStats: (worm: Worm) => {
     strength: number;
     dexterity: number; 
@@ -26,11 +28,13 @@ interface InventoryProps {
 export const Inventory = ({ 
   inventory, 
   items, 
-  worm, 
-  onUseItem, 
-  onEquipItem, 
+  worm,
+  onUseItem,
+  onEquipItem,
   onUnequipItem,
-  getTotalStats 
+  onListItem,
+  onSellToShop,
+  getTotalStats
 }: InventoryProps) => {
   const getItemDetails = (itemId: string) => 
     items.find(item => item.id === itemId);
@@ -215,13 +219,32 @@ export const Inventory = ({
                                     )}
                                   </div>
                                 </div>
-                                <Button
-                                  size="sm"
-                                  onClick={() => onEquipItem(item.id)}
-                                  disabled={isEquipped || (item.level && worm.level < item.level)}
-                                >
-                                  {isEquipped ? 'Felöltve' : 'Felöltés'}
-                                </Button>
+                                <div className="flex gap-2">
+                                  <Button
+                                    size="sm"
+                                    onClick={() => onEquipItem(item.id)}
+                                    disabled={isEquipped || (item.level && worm.level < item.level)}
+                                  >
+                                    {isEquipped ? 'Felöltve' : 'Felöltés'}
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="secondary"
+                                    onClick={() => {
+                                      const price = Number(prompt('Eladási ár?'));
+                                      if (!isNaN(price) && price > 0) onListItem(item.id, price);
+                                    }}
+                                  >
+                                    Piac
+                                  </Button>
+                                  <Button
+                                    size="sm"
+                                    variant="destructive"
+                                    onClick={() => onSellToShop(item.id)}
+                                  >
+                                    Eladás
+                                  </Button>
+                                </div>
                               </div>
                             );
                           })}
@@ -292,14 +315,33 @@ export const Inventory = ({
                             </div>
                           )}
                           
-                          <Button
-                            size="sm"
-                            onClick={() => onUseItem(item.id)}
-                            className="w-full"
-                            disabled={invItem.quantity <= 0}
-                          >
-                            Használat
-                          </Button>
+                          <div className="flex gap-2">
+                            <Button
+                              size="sm"
+                              onClick={() => onUseItem(item.id)}
+                              disabled={invItem.quantity <= 0}
+                              className="flex-1"
+                            >
+                              Használat
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="secondary"
+                              onClick={() => {
+                                const price = Number(prompt('Eladási ár?'));
+                                if (!isNaN(price) && price > 0) onListItem(item.id, price);
+                              }}
+                            >
+                              Piac
+                            </Button>
+                            <Button
+                              size="sm"
+                              variant="destructive"
+                              onClick={() => onSellToShop(item.id)}
+                            >
+                              Eladás
+                            </Button>
+                          </div>
                         </CardContent>
                       </Card>
                     );

--- a/src/components/Market.tsx
+++ b/src/components/Market.tsx
@@ -1,0 +1,68 @@
+import { Card, CardContent, CardHeader, CardTitle } from './ui/card';
+import { Button } from './ui/button';
+import { Badge } from './ui/badge';
+import { Coins } from 'lucide-react';
+import { MarketListing, Item, Worm } from '../types/game';
+
+interface MarketProps {
+  listings: MarketListing[];
+  items: Item[];
+  worm: Worm;
+  onBuy: (listingId: string) => void;
+}
+
+export const Market = ({ listings, items, worm, onBuy }: MarketProps) => {
+  const getItem = (id: string) => items.find(i => i.id === id);
+
+  return (
+    <div className="space-y-6">
+      <div className="text-center">
+        <h2 className="text-3xl font-bold text-primary mb-2">🛒 Piac</h2>
+        <p className="text-muted-foreground mb-4">Vásárolj és adj el tárgyakat más játékosokkal</p>
+        <div className="flex items-center justify-center gap-2">
+          <Coins className="h-5 w-5 text-yellow-500" />
+          <span className="text-xl font-bold">{worm.coins} érme</span>
+        </div>
+      </div>
+      <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {listings.map(listing => {
+          const item = getItem(listing.itemId);
+          if (!item) return null;
+          return (
+            <Card key={listing.id} className="hover:shadow-lg transition-shadow">
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <span className="text-2xl">{item.icon}</span>
+                    <div>
+                      <CardTitle className="text-sm">{item.nameHu}</CardTitle>
+                      <Badge variant="secondary">{listing.seller}</Badge>
+                    </div>
+                  </div>
+                </div>
+              </CardHeader>
+              <CardContent className="pt-0">
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1">
+                    <Coins className="h-3 w-3 text-yellow-500" />
+                    <span className="text-sm font-medium">{listing.price}</span>
+                  </div>
+                  <Button
+                    size="sm"
+                    onClick={() => onBuy(listing.id)}
+                    disabled={worm.coins < listing.price || listing.seller === worm.name}
+                  >
+                    Vásárlás
+                  </Button>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+        {listings.length === 0 && (
+          <p className="text-muted-foreground col-span-full text-center">Nincsenek listázások.</p>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/components/Navigation.tsx
+++ b/src/components/Navigation.tsx
@@ -2,8 +2,8 @@ import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 
 interface NavigationProps {
-  currentPage: 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory' | 'tours' | 'pvp' | 'pve';
-  onNavigate: (page: 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory' | 'tours' | 'pvp' | 'pve') => void;
+  currentPage: 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory' | 'tours' | 'pvp' | 'pve' | 'market';
+  onNavigate: (page: 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory' | 'tours' | 'pvp' | 'pve' | 'market') => void;
   coins: number;
   onLogout: () => void;
 }
@@ -17,6 +17,7 @@ export const Navigation = ({ currentPage, onNavigate, coins, onLogout }: Navigat
     { id: 'pvp', label: 'PvP', icon: '⚔️' },
     { id: 'pve', label: 'PvE', icon: '🐉' },
     { id: 'shop', label: 'Bolt', icon: '🏪' },
+    { id: 'market', label: 'Piac', icon: '🛒' },
     { id: 'inventory', label: 'Táska', icon: '🎒' },
     { id: 'profile', label: 'Profil', icon: '👤' }
   ] as const;

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -12,8 +12,9 @@ import { Inventory } from '../components/Inventory';
 import { TourRoom } from '../components/TourRoom';
 import { UndergroundBox } from '../components/UndergroundBox';
 import { PveArena } from '../components/PveArena';
+import { Market } from '../components/Market';
 
-type Page = 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory' | 'tours' | 'pvp' | 'pve';
+type Page = 'dashboard' | 'training' | 'jobs' | 'profile' | 'shop' | 'inventory' | 'tours' | 'pvp' | 'pve' | 'market';
 
 const Index = () => {
   const [currentPage, setCurrentPage] = useState<Page>('dashboard');
@@ -33,6 +34,9 @@ const Index = () => {
     equipItem,
     unequipItem,
     getTotalStats,
+    sellItemToShop,
+    listItemForSale,
+    buyListing,
     isTourAvailable,
     getTourCooldown,
     startTour,
@@ -110,23 +114,35 @@ const Index = () => {
       
       case 'shop':
         return (
-          <Shop 
+          <Shop
             items={shopItems}
             worm={worm}
             onBuyItem={buyItem}
           />
         );
-      
+
       case 'inventory':
         return (
-          <Inventory 
+          <Inventory
             inventory={inventory}
             items={shopItems}
             worm={worm}
             onUseItem={useItem}
             onEquipItem={equipItem}
             onUnequipItem={unequipItem}
+            onListItem={listItemForSale}
+            onSellToShop={sellItemToShop}
             getTotalStats={getTotalStats}
+          />
+        );
+
+      case 'market':
+        return (
+          <Market
+            listings={gameState.marketListings}
+            items={shopItems}
+            worm={worm}
+            onBuy={buyListing}
           />
         );
       

--- a/src/types/game.ts
+++ b/src/types/game.ts
@@ -146,6 +146,13 @@ export interface InventoryItem {
   acquiredAt: number;
 }
 
+export interface MarketListing {
+  id: string;
+  itemId: string;
+  seller: string;
+  price: number;
+}
+
 export interface TourResult {
   id: string;
   name: string;
@@ -207,6 +214,7 @@ export interface GameState {
   dailyJobsCompleted: number;
   inventory: InventoryItem[];
   shopItems: Item[];
+  marketListings: MarketListing[];
   tourResults: TourResult[];
   battles: Battle[];
   abilities: Ability[];


### PR DESCRIPTION
## Summary
- add Market component with listings
- allow listing inventory items or selling to shop
- wire up navigation and state for marketplace

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b6f96df3fc8322aa32d8b3e792f792