### PR TITLE
fix: avoid duplicate today variable in job acceptance

### DIFF
--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -404,7 +404,6 @@ export const useGameData = () => {
     };
 
     // Daily counter for mood penalty
-    const today = new Date().toDateString();
     const jobCounter = worm.dailyCounters[`job_${jobId}`];
     const jobCount = jobCounter?.date === today ? jobCounter.count : 0;
     const moodPenalty = 5 + jobCount * 2;


### PR DESCRIPTION
## Summary
- remove duplicate `today` declaration in `acceptJob` hook
- reuse existing `today` variable when applying mood penalty and daily counter logic

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b7172b74ac8322a7e22746bf072799