### PR TITLE
Handle network failures in API fetch

### DIFF
--- a/src/hooks/useAuth.ts
+++ b/src/hooks/useAuth.ts
@@ -1,6 +1,7 @@
 import { useRef, useCallback } from 'react';
 import { registerUser as apiRegisterUser, loginUser as apiLoginUser, saveUser as apiSaveUser } from '@/services/auth';
 import type { GameState } from '../types/game';
+import { useToast } from './use-toast';
 
 interface RegisterParams {
   username: string;
@@ -9,6 +10,7 @@ interface RegisterParams {
 }
 
 export const useAuth = () => {
+  const { toast } = useToast();
   const credentialsRef = useRef<{ username: string; password: string } | null>(null);
 
   const registerUser = useCallback(async ({ username, password, data }: RegisterParams) => {
@@ -29,8 +31,13 @@ export const useAuth = () => {
       await apiSaveUser({ username: creds.username, password: creds.password, data: state });
     } catch (err) {
       console.error('Failed to save game state', err);
+      toast({
+        title: 'Hiba',
+        description: err instanceof Error ? err.message : 'Nem sikerült csatlakozni a szerverhez.',
+        variant: 'destructive'
+      });
     }
-  }, []);
+  }, [toast]);
 
   const logout = useCallback(() => {
     credentialsRef.current = null;

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -107,8 +107,13 @@ export const useGameData = () => {
       setGameState(prev => ({ ...prev, marketListings: data.listings || [] }));
     } catch (err) {
       console.error('Failed to fetch market', err);
+      toast({
+        title: 'Hiba',
+        description: err instanceof Error ? err.message : 'Nem sikerült csatlakozni a szerverhez.',
+        variant: 'destructive'
+      });
     }
-  }, []);
+  }, [toast]);
 
   useEffect(() => {
     void fetchMarketListings();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -2,14 +2,19 @@ export const API_BASE = import.meta?.env?.VITE_API_BASE?.replace(/\/+$/, "") || 
 
 export async function apiFetch<T = unknown>(path: string, init?: RequestInit): Promise<T> {
   const url = `${API_BASE}${path.startsWith("/") ? path : `/${path}`}`;
-  const res = await fetch(url, {
-    // do not set mode: 'no-cors'
-    ...init,
-    headers: {
-      "Content-Type": "application/json",
-      ...(init?.headers || {})
-    }
-  });
+  let res: Response;
+  try {
+    res = await fetch(url, {
+      // do not set mode: 'no-cors'
+      ...init,
+      headers: {
+        "Content-Type": "application/json",
+        ...(init?.headers || {})
+      }
+    });
+  } catch {
+    throw new Error("Network request failed");
+  }
 
   let data: unknown = null;
   try {


### PR DESCRIPTION
## Summary
- Detect network failures by wrapping `fetch` calls with try/catch in `apiFetch`
- Display toast when market listings fetch fails
- Surface save-game errors to users via toast

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b76da381288322b88ced9716a58846