### PR TITLE
refactor: modular game data hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,11 @@ Illetve csatolva van a nginx config file "wormapp" névem, és a hozzá tartozó
 │   ├── hooks
 │   │   ├── use-mobile.tsx
 │   │   ├── use-toast.ts
-│   │   └── useGameData.ts
+│   │   ├── useGameData.ts    # GameProvider and aggregator hook
+│   │   ├── useInventory.ts
+│   │   ├── useJobs.ts
+│   │   ├── useMarket.ts
+│   │   └── useTraining.ts
 │   ├── index.css
 │   ├── lib
 │   │   └── utils.ts

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,7 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import { GameProvider } from "./hooks/useGameData";
 
 const queryClient = new QueryClient();
 
@@ -13,13 +14,15 @@ const App = () => (
     <TooltipProvider>
       <Toaster />
       <Sonner />
-      <BrowserRouter>
-        <Routes>
-          <Route path="/" element={<Index />} />
-          {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
-          <Route path="*" element={<NotFound />} />
-        </Routes>
-      </BrowserRouter>
+      <GameProvider>
+        <BrowserRouter>
+          <Routes>
+            <Route path="/" element={<Index />} />
+            {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
+            <Route path="*" element={<NotFound />} />
+          </Routes>
+        </BrowserRouter>
+      </GameProvider>
     </TooltipProvider>
   </QueryClientProvider>
 );

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -1,5 +1,12 @@
-import { useState, useEffect, useCallback } from 'react';
-import { GameState, Worm, User, Training, Job, JobAssignment, Item, InventoryItem, getXpRequiredForLevel, getDiminishingMultiplier, DAILY_JOB_LIMIT, TourResult, Battle, PlayerClass } from '../types/game';
+import { createContext, useContext, useState, useEffect, ReactNode, createElement } from 'react';
+import {
+  GameState,
+  Worm,
+  User,
+  PlayerClass,
+  getXpRequiredForLevel,
+  Item
+} from '../types/game';
 import { defaultTrainings } from '../data/trainings';
 import { defaultJobs } from '../data/jobs';
 import { defaultShopItems, generateRandomEquipment } from '../data/shopItems';
@@ -8,6 +15,10 @@ import { defaultAbilities } from '../data/abilities';
 import { useToast } from './use-toast';
 import defaultWormImage from '../assets/default-worm.png';
 import { useAuth } from './useAuth';
+import { useTraining } from './useTraining';
+import { useJobs } from './useJobs';
+import { useInventory } from './useInventory';
+import { useMarket } from './useMarket';
 
 const STORAGE_KEY = 'worm-daycare-data';
 
@@ -81,15 +92,14 @@ const defaultGameState: GameState = {
   leaderboard: []
 };
 
-export const useGameData = () => {
+const useGameDataInternal = () => {
   const [gameState, setGameState] = useState<GameState>(() => {
     const stored = localStorage.getItem(STORAGE_KEY);
     if (stored) {
       try {
         const parsed = JSON.parse(stored);
         return { ...defaultGameState, ...parsed };
-      } catch (error) {
-        console.warn('Failed to parse game data from localStorage', error);
+      } catch {
         localStorage.removeItem(STORAGE_KEY);
       }
     }
@@ -99,27 +109,15 @@ export const useGameData = () => {
   const { toast } = useToast();
   const { registerUser: authRegisterUser, loginUser: authLoginUser, saveGame, logout: authLogout } = useAuth();
 
-  const fetchMarketListings = useCallback(async () => {
-    try {
-      const res = await fetch('/api/market');
-      if (!res.ok) return;
-      const data = await res.json();
-      setGameState(prev => ({ ...prev, marketListings: data.listings || [] }));
-    } catch (err) {
-      console.error('Failed to fetch market', err);
-    }
-  }, []);
+  const training = useTraining(gameState, setGameState, toast);
+  const jobs = useJobs(gameState, setGameState, toast);
+  const inventory = useInventory(gameState, setGameState, toast);
+  const market = useMarket(gameState, setGameState, toast);
 
-  useEffect(() => {
-    void fetchMarketListings();
-  }, [fetchMarketListings]);
-
-  // Save to localStorage whenever gameState changes
   useEffect(() => {
     localStorage.setItem(STORAGE_KEY, JSON.stringify(gameState));
   }, [gameState]);
 
-  // Periodically save to server every 5 minutes
   useEffect(() => {
     const interval = setInterval(() => {
       saveGame(gameState);
@@ -127,23 +125,16 @@ export const useGameData = () => {
     return () => clearInterval(interval);
   }, [saveGame, gameState]);
 
-  // Energy regeneration system
   useEffect(() => {
     if (!gameState.worm) return;
-
     const interval = setInterval(() => {
       setGameState(prev => {
         if (!prev.worm || prev.worm.energy >= 100) return prev;
-
         const timeSinceLastUpdate = Date.now() - prev.worm.lastUpdated;
         const minutesSinceUpdate = timeSinceLastUpdate / (1000 * 60);
-        
-        // Regenerate 1 energy per minute
         const energyToRestore = Math.floor(minutesSinceUpdate);
-        
         if (energyToRestore > 0) {
           const newEnergy = Math.min(100, prev.worm.energy + energyToRestore);
-          
           return {
             ...prev,
             worm: {
@@ -153,11 +144,9 @@ export const useGameData = () => {
             }
           };
         }
-        
         return prev;
       });
-    }, 60000); // Check every minute
-
+    }, 60000);
     return () => clearInterval(interval);
   }, [gameState.worm]);
 
@@ -167,7 +156,6 @@ export const useGameData = () => {
     wormName: string,
     playerClass: PlayerClass
   ) => {
-    // Clear any previously cached game state to avoid leaking data between users
     localStorage.removeItem(STORAGE_KEY);
 
     const user = createInitialUser(username);
@@ -184,7 +172,7 @@ export const useGameData = () => {
     try {
       await authRegisterUser({ username, password, data: newState });
       toast({
-        title: "Üdvözöllek!",
+        title: 'Üdvözöllek!',
         description: `${wormName} kukac sikeresen létrehozva!`
       });
     } catch (err) {
@@ -200,9 +188,7 @@ export const useGameData = () => {
 
   const loginUser = async (username: string, password: string) => {
     try {
-      // Ensure old cached data doesn't persist when switching accounts
       localStorage.removeItem(STORAGE_KEY);
-
       const data = await authLoginUser(username, password);
       setGameState({ ...defaultGameState, ...data });
     } catch (err) {
@@ -215,647 +201,15 @@ export const useGameData = () => {
     }
   };
 
-  // Check if training is available (not on cooldown)
-  const isTrainingAvailable = (trainingId: string): boolean => {
-    if (!gameState.worm) return false;
-    const cooldownEnd = gameState.worm.cooldowns[trainingId];
-    return !cooldownEnd || Date.now() >= cooldownEnd;
-  };
-
-  // Get remaining cooldown time in seconds
-  const getTrainingCooldown = (trainingId: string): number => {
-    if (!gameState.worm) return 0;
-    const cooldownEnd = gameState.worm.cooldowns[trainingId];
-    if (!cooldownEnd) return 0;
-    return Math.max(0, Math.ceil((cooldownEnd - Date.now()) / 1000));
-  };
-
-  // Execute training
-  const executeTrain = (trainingId: string) => {
-    const training = gameState.trainings.find(t => t.id === trainingId);
-    if (!training || !gameState.worm) return;
-
-    const worm = gameState.worm;
-
-    // Prevent action if another activity is running
-    if (worm.currentActivity && Date.now() < worm.currentActivity.endsAt) {
-      toast({
-        title: "Már folyamatban van egy tevékenység!",
-        description: "Várd meg, míg az előző befejeződik.",
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check energy
-    if (worm.energy < training.energyCost) {
-      toast({
-        title: "Nincs elég energia!",
-        description: `${training.nameHu} ${training.energyCost} energiát igényel.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check coins
-    if (training.coinCost && worm.coins < training.coinCost) {
-      toast({
-        title: "Nincs elég érme!",
-        description: `${training.nameHu} ${training.coinCost} érmét igényel.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check cooldown
-    if (!isTrainingAvailable(trainingId)) {
-      const remaining = getTrainingCooldown(trainingId);
-      toast({
-        title: "Még várnod kell!",
-        description: `${training.nameHu} még ${Math.ceil(remaining / 60)} perc múlva lesz elérhető.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Get daily counter for diminishing returns
-    const today = new Date().toDateString();
-    const dailyCounter = worm.dailyCounters[trainingId];
-    const todayCount = (dailyCounter?.date === today) ? dailyCounter.count : 0;
-    const multiplier = getDiminishingMultiplier(todayCount);
-
-    // Calculate gains with diminishing returns
-    const actualStatGain = Math.floor(training.statGain * multiplier);
-    const actualXpGain = Math.floor(training.xpGain * multiplier);
-
-    // Mood penalty increases with repeated trainings
-    const moodPenalty = 5 + todayCount * 2;
-
-    // Update worm
-    const updatedWorm: Worm = {
-      ...worm,
-      energy: worm.energy - training.energyCost,
-      coins: worm.coins - (training.coinCost || 0),
-      xp: worm.xp + actualXpGain,
-      mood: Math.max(0, worm.mood - moodPenalty),
-      [training.statFocus]: worm[training.statFocus] + actualStatGain,
-      cooldowns: {
-        ...worm.cooldowns,
-        [trainingId]: Date.now() + training.cooldownSeconds * 1000
-      },
-      dailyCounters: {
-        ...worm.dailyCounters,
-        [trainingId]: { date: today, count: todayCount + 1 }
-      },
-      currentActivity: {
-        type: 'training',
-        endsAt: Date.now() + training.cooldownSeconds * 1000
-      },
-      lastUpdated: Date.now()
-    };
-
-    // Check for level up
-    let newLevel = updatedWorm.level;
-    while (updatedWorm.xp >= getXpRequiredForLevel(newLevel + 1)) {
-      newLevel++;
-    }
-
-    if (newLevel > updatedWorm.level) {
-      updatedWorm.level = newLevel;
-      toast({
-        title: "Szint lépés! 🎉",
-        description: `${worm.name} elérte a ${newLevel}. szintet!`
-      });
-    }
-
-    setGameState(prev => ({ ...prev, worm: updatedWorm }));
-
-    toast({
-      title: "Edzés befejezve!",
-      description: `+${actualStatGain} ${training.statFocus === 'strength' ? 'Erő' : 
-        training.statFocus === 'dexterity' ? 'Ügyesség' : 
-        training.statFocus === 'endurance' ? 'Kitartás' : 
-        training.statFocus === 'stamina' ? 'Állóképesség' : 
-        training.statFocus === 'intelligence' ? 'Intelligencia' : 'Karizma'}, +${actualXpGain} XP`
-    });
-  };
-
-  // Accept a job
-  const acceptJob = (jobId: string) => {
-    const job = gameState.jobs.find(j => j.id === jobId);
-    if (!job || !gameState.worm) return;
-
-    const worm = gameState.worm;
-
-    // Prevent action if another activity is running
-    if (worm.currentActivity && Date.now() < worm.currentActivity.endsAt) {
-      toast({
-        title: "Már folyamatban van egy tevékenység!",
-        description: "Várd meg, míg az előző befejeződik.",
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check daily job limit
-    const today = new Date().toDateString();
-    const todayAssignments = gameState.jobAssignments.filter(ja => 
-      new Date(ja.startedAt).toDateString() === today
-    );
-    
-    if (todayAssignments.length >= DAILY_JOB_LIMIT) {
-      toast({
-        title: "Napi limit elérve!",
-        description: `Ma már ${DAILY_JOB_LIMIT} munkát végeztél el.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check level requirement
-    if (worm.level < job.minLevel) {
-      toast({
-        title: "Túl alacsony szint!",
-        description: `${job.nameHu} ${job.minLevel}. szintet igényel.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check energy
-    if (worm.energy < job.energyCost) {
-      toast({
-        title: "Nincs elég energia!",
-        description: `${job.nameHu} ${job.energyCost} energiát igényel.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check stat requirements
-    for (const [stat, required] of Object.entries(job.statRequirements)) {
-      const statValue = worm[stat as keyof Pick<Worm, 'strength' | 'dexterity' | 'endurance' | 'stamina' | 'intelligence' | 'charisma'>] as number;
-      if (statValue < (required as number)) {
-        const statName = stat === 'strength' ? 'Erő' : 
-          stat === 'dexterity' ? 'Ügyesség' : 
-          stat === 'endurance' ? 'Kitartás' : 
-          stat === 'stamina' ? 'Állóképesség' : 
-          stat === 'intelligence' ? 'Intelligencia' : 'Karizma';
-        toast({
-          title: "Nem elég magas stat!",
-          description: `${job.nameHu} ${required} ${statName}-t igényel.`,
-          variant: "destructive"
-        });
-        return;
-      }
-    }
-
-    // Create job assignment
-    const assignment: JobAssignment = {
-      id: Date.now().toString(),
-      jobId,
-      status: 'accepted',
-      startedAt: Date.now(),
-    };
-
-    // Daily counter for mood penalty
-    const jobCounter = worm.dailyCounters[`job_${jobId}`];
-    const jobCount = jobCounter?.date === today ? jobCounter.count : 0;
-    const moodPenalty = 5 + jobCount * 2;
-
-    // Deduct energy immediately and apply mood change
-    const updatedWorm: Worm = {
-      ...worm,
-      energy: worm.energy - job.energyCost,
-      mood: Math.max(0, worm.mood - moodPenalty),
-      currentActivity: {
-        type: 'job',
-        endsAt: Date.now() + job.durationMinutes * 60 * 1000
-      },
-      dailyCounters: {
-        ...worm.dailyCounters,
-        [`job_${jobId}`]: { date: today, count: jobCount + 1 }
-      },
-      lastUpdated: Date.now()
-    };
-
-    setGameState(prev => ({
-      ...prev,
-      worm: updatedWorm,
-      jobAssignments: [...prev.jobAssignments, assignment]
-    }));
-
-    toast({
-      title: "Munka elfogadva!",
-      description: `${job.nameHu} - ${job.durationMinutes} perc múlva fejezheted be.`
-    });
-  };
-
-  // Complete a job
-  const completeJob = (assignmentId: string) => {
-    const assignment = gameState.jobAssignments.find(ja => ja.id === assignmentId);
-    const job = assignment ? gameState.jobs.find(j => j.id === assignment.jobId) : null;
-    
-    if (!assignment || !job || !gameState.worm || assignment.status !== 'accepted') return;
-
-    // Check if enough time has passed
-    const timeElapsed = Date.now() - assignment.startedAt;
-    const requiredTime = job.durationMinutes * 60 * 1000;
-    
-    if (timeElapsed < requiredTime) {
-      const remainingMinutes = Math.ceil((requiredTime - timeElapsed) / (60 * 1000));
-      toast({
-        title: "Még nem fejezhető be!",
-        description: `${remainingMinutes} perc van hátra.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    const worm = gameState.worm;
-
-    // Update worm with rewards
-    const updatedWorm: Worm = {
-      ...worm,
-      coins: worm.coins + job.rewardCoins,
-      xp: worm.xp + job.rewardXp,
-      currentActivity: undefined,
-      lastUpdated: Date.now()
-    };
-
-    // Check for level up
-    let newLevel = updatedWorm.level;
-    while (updatedWorm.xp >= getXpRequiredForLevel(newLevel + 1)) {
-      newLevel++;
-    }
-
-    if (newLevel > updatedWorm.level) {
-      updatedWorm.level = newLevel;
-      toast({
-        title: "Szint lépés! 🎉",
-        description: `${worm.name} elérte a ${newLevel}. szintet!`
-      });
-    }
-
-    // Update assignment status
-    const updatedAssignments = gameState.jobAssignments.map(ja =>
-      ja.id === assignmentId 
-        ? { ...ja, status: 'completed' as const, completedAt: Date.now() }
-        : ja
-    );
-
-    setGameState(prev => ({
-      ...prev,
-      worm: updatedWorm,
-      jobAssignments: updatedAssignments
-    }));
-
-    toast({
-      title: "Munka befejezve! 💰",
-      description: `+${job.rewardCoins} érme, +${job.rewardXp} XP`
-    });
-  };
-
-  // Update worm profile
   const updateWormProfile = (updates: Partial<Pick<Worm, 'name' | 'avatarUrl'>>) => {
     if (!gameState.worm) return;
-
     setGameState(prev => ({
       ...prev,
       worm: prev.worm ? { ...prev.worm, ...updates, lastUpdated: Date.now() } : null
     }));
-
-    toast({
-      title: "Profil frissítve!",
-      description: "A változások elmentve."
-    });
+    toast({ title: 'Profil frissítve!', description: 'A változások elmentve.' });
   };
 
-  // Buy item from shop
-  const buyItem = (itemId: string) => {
-    const item = gameState.shopItems.find(i => i.id === itemId);
-    if (!item || !gameState.worm) return;
-
-    const worm = gameState.worm;
-
-    // Check if player has enough coins
-    if (worm.coins < item.price) {
-      toast({
-        title: "Nincs elég érme!",
-        description: `${item.nameHu} ${item.price} érmét igényel.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check level requirement for equipment
-    if (item.level && worm.level < item.level) {
-      toast({
-        title: "Túl alacsony szint!",
-        description: `${item.nameHu} ${item.level}. szintet igényel.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Add to inventory
-    const existingItem = gameState.inventory.find(inv => inv.itemId === itemId);
-    const updatedInventory = existingItem 
-      ? gameState.inventory.map(inv => 
-          inv.itemId === itemId 
-            ? { ...inv, quantity: inv.quantity + 1 }
-            : inv
-        )
-      : [...gameState.inventory, { itemId, quantity: 1, acquiredAt: Date.now() }];
-
-    // Deduct coins
-    const updatedWorm: Worm = {
-      ...worm,
-      coins: worm.coins - item.price,
-      lastUpdated: Date.now()
-    };
-
-    setGameState(prev => ({
-      ...prev,
-      worm: updatedWorm,
-      inventory: updatedInventory
-    }));
-
-    toast({
-      title: "Vásárlás sikeres!",
-      description: `${item.nameHu} hozzáadva a táskádhoz.`
-    });
-  };
-
-  // Use consumable item
-  const useItem = (itemId: string) => {
-    const inventoryItem = gameState.inventory.find(inv => inv.itemId === itemId);
-    const item = gameState.shopItems.find(i => i.id === itemId);
-    
-    if (!inventoryItem || !item || !gameState.worm || inventoryItem.quantity <= 0) return;
-
-    if (item.type !== 'consumable') {
-      toast({
-        title: "Nem használható!",
-        description: "Ez a tárgy nem használható fel.",
-        variant: "destructive"
-      });
-      return;
-    }
-
-    const worm = gameState.worm;
-    const effects = item.effects || {};
-
-    // Apply effects
-    const updatedWorm: Worm = {
-      ...worm,
-      energy: Math.min(100, worm.energy + (effects.energy || 0)),
-      health: Math.min(100, worm.health + (effects.health || 0)),
-      mood: Math.min(100, worm.mood + (effects.mood || 0)),
-      strength: worm.strength + (effects.strength || 0),
-      dexterity: worm.dexterity + (effects.dexterity || 0),
-      endurance: worm.endurance + (effects.endurance || 0),
-      stamina: worm.stamina + (effects.stamina || 0),
-      intelligence: worm.intelligence + (effects.intelligence || 0),
-      charisma: worm.charisma + (effects.charisma || 0),
-      lastUpdated: Date.now()
-    };
-
-    // Remove one from inventory
-    const updatedInventory = inventoryItem.quantity === 1
-      ? gameState.inventory.filter(inv => inv.itemId !== itemId)
-      : gameState.inventory.map(inv => 
-          inv.itemId === itemId 
-            ? { ...inv, quantity: inv.quantity - 1 }
-            : inv
-        );
-
-    setGameState(prev => ({
-      ...prev,
-      worm: updatedWorm,
-      inventory: updatedInventory
-    }));
-
-    toast({
-      title: "Tárgy használva!",
-      description: `${item.nameHu} hatása alkalmazva.`
-    });
-  };
-
-  // Equip item
-  const equipItem = (itemId: string) => {
-    const inventoryItem = gameState.inventory.find(inv => inv.itemId === itemId);
-    const item = gameState.shopItems.find(i => i.id === itemId);
-    
-    if (!inventoryItem || !item || !gameState.worm || item.type !== 'equipment') return;
-
-    const worm = gameState.worm;
-    const slot = item.subType as keyof typeof worm.equipment;
-
-    if (!slot || !['helmet', 'armor', 'weapon', 'accessory'].includes(slot)) {
-      toast({
-        title: "Hiba!",
-        description: "Ismeretlen felszerelés típus.",
-        variant: "destructive"
-      });
-      return;
-    }
-
-    // Check level requirement
-    if (item.level && worm.level < item.level) {
-      toast({
-        title: "Túl alacsony szint!",
-        description: `${item.nameHu} ${item.level}. szintet igényel.`,
-        variant: "destructive"
-      });
-      return;
-    }
-
-    const updatedWorm: Worm = {
-      ...worm,
-      equipment: {
-        ...worm.equipment,
-        [slot]: itemId
-      },
-      lastUpdated: Date.now()
-    };
-
-    setGameState(prev => ({
-      ...prev,
-      worm: updatedWorm
-    }));
-
-    toast({
-      title: "Felszerelés felöltve!",
-      description: `${item.nameHu} sikeresen felöltve.`
-    });
-  };
-
-  // Unequip item
-  const unequipItem = (slot: keyof Worm['equipment']) => {
-    if (!gameState.worm) return;
-
-    const updatedWorm: Worm = {
-      ...gameState.worm,
-      equipment: {
-        ...gameState.worm.equipment,
-        [slot]: undefined
-      },
-      lastUpdated: Date.now()
-    };
-
-    setGameState(prev => ({
-      ...prev,
-      worm: updatedWorm
-    }));
-
-    toast({
-      title: "Felszerelés levéve!",
-      description: "Tárgy sikeresen levéve."
-    });
-  };
-
-  const sellItemToShop = (itemId: string) => {
-    const inventoryItem = gameState.inventory.find(inv => inv.itemId === itemId);
-    const item = gameState.shopItems.find(i => i.id === itemId);
-    if (!inventoryItem || !item || !gameState.worm) return;
-
-    const ranges: Record<Item['rarity'], [number, number]> = {
-      common: [30, 50],
-      rare: [50, 75],
-      epic: [75, 90],
-      legendary: [90, 100],
-    };
-    const [min, max] = ranges[item.rarity];
-    const price = Math.floor(Math.random() * (max - min + 1)) + min;
-
-    const updatedInventory = inventoryItem.quantity === 1
-      ? gameState.inventory.filter(inv => inv.itemId !== itemId)
-      : gameState.inventory.map(inv =>
-          inv.itemId === itemId ? { ...inv, quantity: inv.quantity - 1 } : inv
-        );
-
-    const updatedWorm: Worm = {
-      ...gameState.worm,
-      coins: gameState.worm.coins + price,
-      lastUpdated: Date.now(),
-    };
-
-    setGameState(prev => ({
-      ...prev,
-      worm: updatedWorm,
-      inventory: updatedInventory,
-    }));
-
-    toast({ title: 'Eladva!', description: `${item.nameHu} eladva ${price} érméért.` });
-  };
-
-  const listItemForSale = async (itemId: string, price: number) => {
-    const inventoryItem = gameState.inventory.find(inv => inv.itemId === itemId);
-    const item = gameState.shopItems.find(i => i.id === itemId);
-    if (!inventoryItem || !item || !gameState.user) return;
-
-    const updatedInventory = inventoryItem.quantity === 1
-      ? gameState.inventory.filter(inv => inv.itemId !== itemId)
-      : gameState.inventory.map(inv =>
-          inv.itemId === itemId ? { ...inv, quantity: inv.quantity - 1 } : inv
-        );
-
-    try {
-      const res = await fetch('/api/market/list', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ itemId, price, seller: gameState.user.username }),
-      });
-      if (!res.ok) throw new Error('Failed to list');
-      const data = await res.json();
-      const listing = data.listing;
-      setGameState(prev => ({
-        ...prev,
-        inventory: updatedInventory,
-        marketListings: [...prev.marketListings, listing],
-      }));
-      toast({ title: 'Piacra téve!', description: `${item.nameHu} listázva ${price} érméért.` });
-    } catch (err) {
-      console.error('Failed to list item', err);
-      toast({ title: 'Hiba', description: 'Nem sikerült feltölteni a piacra.', variant: 'destructive' });
-    }
-  };
-
-  const buyListing = async (listingId: string) => {
-    const listing = gameState.marketListings.find(l => l.id === listingId);
-    if (!listing || !gameState.worm) return;
-    if (listing.price > gameState.worm.coins) {
-      toast({ title: 'Nincs elég érme!', description: 'Nem tudod megvenni ezt a tárgyat.', variant: 'destructive' });
-      return;
-    }
-
-    const item = gameState.shopItems.find(i => i.id === listing.itemId);
-    if (!item) return;
-
-    const existingItem = gameState.inventory.find(inv => inv.itemId === listing.itemId);
-    const updatedInventory = existingItem
-      ? gameState.inventory.map(inv =>
-          inv.itemId === listing.itemId ? { ...inv, quantity: inv.quantity + 1 } : inv
-        )
-      : [...gameState.inventory, { itemId: listing.itemId, quantity: 1, acquiredAt: Date.now() }];
-
-    const updatedWorm: Worm = {
-      ...gameState.worm,
-      coins: gameState.worm.coins - listing.price,
-      lastUpdated: Date.now(),
-    };
-
-    try {
-      const res = await fetch('/api/market/remove', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ listingId }),
-      });
-      if (!res.ok) throw new Error('Failed to remove');
-      setGameState(prev => ({
-        ...prev,
-        worm: updatedWorm,
-        inventory: updatedInventory,
-        marketListings: prev.marketListings.filter(l => l.id !== listingId),
-      }));
-      toast({ title: 'Vásárlás sikeres!', description: `${item.nameHu} megvásárolva.` });
-    } catch (err) {
-      console.error('Failed to buy listing', err);
-      toast({ title: 'Hiba', description: 'Nem sikerült megvásárolni a tárgyat.', variant: 'destructive' });
-    }
-  };
-
-  // Get total stats including equipment bonuses
-  const getTotalStats = (worm: Worm) => {
-    const totalStats = {
-      strength: worm.strength,
-      dexterity: worm.dexterity,
-      endurance: worm.endurance,
-      stamina: worm.stamina,
-      intelligence: worm.intelligence,
-      charisma: worm.charisma
-    };
-
-    // Add equipment bonuses
-    Object.values(worm.equipment).forEach(itemId => {
-      if (itemId) {
-        const item = gameState.shopItems.find(i => i.id === itemId);
-        if (item?.statBonus) {
-          totalStats.strength += item.statBonus.strength || 0;
-          totalStats.dexterity += item.statBonus.dexterity || 0;
-          totalStats.endurance += item.statBonus.endurance || 0;
-          totalStats.stamina += item.statBonus.stamina || 0;
-          totalStats.intelligence += item.statBonus.intelligence || 0;
-          totalStats.charisma += item.statBonus.charisma || 0;
-        }
-      }
-    });
-
-    return totalStats;
-  };
-
-  // Tour functions
   const isTourAvailable = (tourId: string): boolean => {
     if (!gameState.worm) return false;
     const cooldownTime = gameState.worm.tourCooldowns[tourId] || 0;
@@ -871,50 +225,29 @@ export const useGameData = () => {
 
   const startTour = (tourId: string): void => {
     if (!gameState.worm) return;
-
     const tour = gameState.tourResults.find(t => t.id === tourId);
     if (!tour) return;
 
     if (gameState.worm.currentActivity && Date.now() < gameState.worm.currentActivity.endsAt) {
-      toast({
-        title: "Már folyamatban van egy tevékenység!",
-        description: "Várd meg, míg az előző befejeződik.",
-        variant: "destructive",
-      });
+      toast({ title: 'Már folyamatban van egy tevékenység!', description: 'Várd meg, míg az előző befejeződik.', variant: 'destructive' });
       return;
     }
 
-    // Check requirements
     if (gameState.worm.level < tour.minLevel) {
-      toast({
-        title: "Szint túl alacsony",
-        description: `${tour.minLevel}. szint szükséges ehhez a túrához.`,
-        variant: "destructive",
-      });
+      toast({ title: 'Szint túl alacsony', description: `${tour.minLevel}. szint szükséges ehhez a túrához.`, variant: 'destructive' });
       return;
     }
-
     if (gameState.worm.energy < tour.energyCost) {
-      toast({
-        title: "Nincs elég energia",
-        description: `${tour.energyCost} energia szükséges.`,
-        variant: "destructive",
-      });
+      toast({ title: 'Nincs elég energia', description: `${tour.energyCost} energia szükséges.`, variant: 'destructive' });
       return;
     }
-
     if (!isTourAvailable(tourId)) {
-      toast({
-        title: "Túra még nem elérhető",
-        description: "Várj még egy kicsit!",
-        variant: "destructive",
-      });
+      toast({ title: 'Túra még nem elérhető', description: 'Várj még egy kicsit!', variant: 'destructive' });
       return;
     }
 
     setGameState(prev => {
       if (!prev.worm) return prev;
-
       const today = new Date().toDateString();
       const counter = prev.worm.dailyCounters[`tour_${tourId}`];
       const count = counter?.date === today ? counter.count : 0;
@@ -924,334 +257,171 @@ export const useGameData = () => {
         ...prev.worm,
         energy: prev.worm.energy - tour.energyCost,
         mood: Math.max(0, Math.min(100, prev.worm.mood + moodChange)),
-        tourCooldowns: {
-          ...prev.worm.tourCooldowns,
-          [tourId]: Date.now() + (tour.duration * 60 * 1000) // Convert minutes to milliseconds
-        },
-        dailyCounters: {
-          ...prev.worm.dailyCounters,
-          [`tour_${tourId}`]: { date: today, count: count + 1 }
-        },
-        currentActivity: {
-          type: 'tour',
-          endsAt: Date.now() + tour.duration * 60 * 1000
-        }
+        tourCooldowns: { ...prev.worm.tourCooldowns, [tourId]: Date.now() + tour.duration * 60 * 1000 },
+        dailyCounters: { ...prev.worm.dailyCounters, [`tour_${tourId}`]: { date: today, count: count + 1 } },
+        currentActivity: { type: 'tour', endsAt: Date.now() + tour.duration * 60 * 1000 }
       };
 
-      // Generate random equipment reward (chance based on tier)
       let rewardItem: Item | null = null;
-      const dropChance = tour.tier === 'low' ? 0.3 : 
+      const dropChance = tour.tier === 'low' ? 0.3 :
                         tour.tier === 'mid-bottom' ? 0.4 :
                         tour.tier === 'mid-top' ? 0.5 :
                         tour.tier === 'high-bottom' ? 0.6 :
                         tour.tier === 'high-middle' ? 0.7 : 0.8;
-
       if (Math.random() < dropChance) {
         rewardItem = generateRandomEquipment(tour.tier, randomEquipmentSubType());
       }
 
-      const updatedInventory = rewardItem 
-        ? [...prev.inventory, { itemId: rewardItem.id, quantity: 1, acquiredAt: Date.now() }]
-        : prev.inventory;
-
-      const updatedShopItems = rewardItem 
-        ? [...prev.shopItems, rewardItem]
-        : prev.shopItems;
+      const updatedInventory = rewardItem ? [...prev.inventory, { itemId: rewardItem.id, quantity: 1, acquiredAt: Date.now() }] : prev.inventory;
+      const updatedShopItems = rewardItem ? [...prev.shopItems, rewardItem] : prev.shopItems;
 
       toast({
-        title: "Túra elkezdve!",
-        description: rewardItem 
-          ? `Túra elkezdve! ${tour.duration} perc múlva visszatérsz. Találtál egy tárgyat: ${rewardItem.nameHu}!`
-          : `Túra elkezdve! ${tour.duration} perc múlva visszatérsz.`,
+        title: 'Túra elkezdve!',
+        description: rewardItem ? `Túra elkezdve! ${tour.duration} perc múlva visszatérsz. Találtál egy tárgyat: ${rewardItem.nameHu}!` : `Túra elkezdve! ${tour.duration} perc múlva visszatérsz.`,
       });
 
-      return {
-        ...prev,
-        worm: updatedWorm,
-        inventory: updatedInventory,
-        shopItems: updatedShopItems
-      };
+      return { ...prev, worm: updatedWorm, inventory: updatedInventory, shopItems: updatedShopItems };
     });
   };
 
-  // PvE functions
   const startDungeon = (difficulty: 'easy' | 'medium' | 'hard' | 'elite'): void => {
     if (!gameState.worm) return;
-
     if (gameState.worm.currentActivity && Date.now() < gameState.worm.currentActivity.endsAt) {
-      toast({
-        title: "Már folyamatban van egy tevékenység!",
-        description: "Várd meg, míg az előző befejeződik.",
-        variant: "destructive",
-      });
+      toast({ title: 'Már folyamatban van egy tevékenység!', description: 'Várd meg, míg az előző befejeződik.', variant: 'destructive' });
       return;
     }
-
     const dungeonData = {
       easy: { energyCost: 15, minLevel: 1, tier: 'low' as const, xpReward: 20, durationMinutes: 5 },
       medium: { energyCost: 25, minLevel: 5, tier: 'mid-bottom' as const, xpReward: 40, durationMinutes: 10 },
       hard: { energyCost: 35, minLevel: 10, tier: 'mid-top' as const, xpReward: 60, durationMinutes: 15 },
       elite: { energyCost: 50, minLevel: 15, tier: 'high-bottom' as const, xpReward: 100, durationMinutes: 20 }
     };
-
     const dungeon = dungeonData[difficulty];
-
-    // Check requirements
     if (gameState.worm.level < dungeon.minLevel) {
-      toast({
-        title: "Szint túl alacsony",
-        description: `${dungeon.minLevel}. szint szükséges ehhez a börtönhöz.`,
-        variant: "destructive",
-      });
+      toast({ title: 'Szint túl alacsony', description: `${dungeon.minLevel}. szint szükséges ehhez a börtönhöz.`, variant: 'destructive' });
       return;
     }
-
     if (gameState.worm.energy < dungeon.energyCost) {
-      toast({
-        title: "Nincs elég energia",
-        description: `${dungeon.energyCost} energia szükséges.`,
-        variant: "destructive",
-      });
+      toast({ title: 'Nincs elég energia', description: `${dungeon.energyCost} energia szükséges.`, variant: 'destructive' });
       return;
     }
-
     setGameState(prev => {
       if (!prev.worm) return prev;
-
-      // Generate rewards
       const xpGained = dungeon.xpReward;
       const newXp = prev.worm.xp + xpGained;
       const newLevel = calculateLevel(newXp);
       const leveledUp = newLevel > prev.worm.level;
-
-      // Equipment drop (higher chance than tours since it's combat)
       let rewardItem: Item | null = null;
-      const dropChance = difficulty === 'easy' ? 0.4 : 
-                        difficulty === 'medium' ? 0.6 :
-                        difficulty === 'hard' ? 0.75 : 0.9;
-
+      const dropChance = difficulty === 'easy' ? 0.4 : difficulty === 'medium' ? 0.6 : difficulty === 'hard' ? 0.75 : 0.9;
       if (Math.random() < dropChance) {
         rewardItem = generateRandomEquipment(dungeon.tier, randomEquipmentSubType());
       }
-
       const updatedWorm = {
         ...prev.worm,
         energy: prev.worm.energy - dungeon.energyCost,
         xp: newXp,
         level: newLevel,
-        currentActivity: {
-          type: 'dungeon',
-          endsAt: Date.now() + dungeon.durationMinutes * 60 * 1000
-        }
+        currentActivity: { type: 'dungeon', endsAt: Date.now() + dungeon.durationMinutes * 60 * 1000 }
       };
-
-      const updatedInventory = rewardItem 
-        ? [...prev.inventory, { itemId: rewardItem.id, quantity: 1, acquiredAt: Date.now() }]
-        : prev.inventory;
-
-      const updatedShopItems = rewardItem 
-        ? [...prev.shopItems, rewardItem]
-        : prev.shopItems;
-
+      const updatedInventory = rewardItem ? [...prev.inventory, { itemId: rewardItem.id, quantity: 1, acquiredAt: Date.now() }] : prev.inventory;
+      const updatedShopItems = rewardItem ? [...prev.shopItems, rewardItem] : prev.shopItems;
       toast({
-        title: "Börtön teljesítve!",
-        description: rewardItem 
-          ? `${xpGained} XP szerzett! Találtál: ${rewardItem.nameHu}${leveledUp ? ` Új szint: ${newLevel}!` : ''}`
-          : `${xpGained} XP szerzett!${leveledUp ? ` Új szint: ${newLevel}!` : ''}`,
+        title: 'Börtön teljesítve!',
+        description: rewardItem ? `${xpGained} XP! Zsákmány: ${rewardItem.nameHu}${leveledUp ? ` Új szint: ${newLevel}!` : ''}` : `${xpGained} XP szerzett!${leveledUp ? ` Új szint: ${newLevel}!` : ''}`,
       });
-
-      return {
-        ...prev,
-        worm: updatedWorm,
-        inventory: updatedInventory,
-        shopItems: updatedShopItems
-      };
+      return { ...prev, worm: updatedWorm, inventory: updatedInventory, shopItems: updatedShopItems };
     });
   };
 
   const startRaid = (): void => {
     if (!gameState.worm) return;
-
     if (gameState.worm.currentActivity && Date.now() < gameState.worm.currentActivity.endsAt) {
-      toast({
-        title: "Már folyamatban van egy tevékenység!",
-        description: "Várd meg, míg az előző befejeződik.",
-        variant: "destructive",
-      });
+      toast({ title: 'Már folyamatban van egy tevékenység!', description: 'Várd meg, míg az előző befejeződik.', variant: 'destructive' });
       return;
     }
-
-    // Check requirements
     if (gameState.worm.level < 12) {
-      toast({
-        title: "Szint túl alacsony",
-        description: "12. szint szükséges raid-ekhez.",
-        variant: "destructive",
-      });
+      toast({ title: 'Szint túl alacsony', description: '12. szint szükséges a raidhez.', variant: 'destructive' });
       return;
     }
-
     if (gameState.worm.energy < 40) {
-      toast({
-        title: "Nincs elég energia",
-        description: "40 energia szükséges.",
-        variant: "destructive",
-      });
+      toast({ title: 'Nincs elég energia', description: '40 energia szükséges.', variant: 'destructive' });
       return;
     }
-
     setGameState(prev => {
       if (!prev.worm) return prev;
-
-      // Raid rewards (guaranteed equipment + high XP)
       const xpGained = 150;
       const newXp = prev.worm.xp + xpGained;
       const newLevel = calculateLevel(newXp);
       const leveledUp = newLevel > prev.worm.level;
-
-      // Always drop equipment from raids, chance for multiple items
       const rewards: Item[] = [];
-      rewards.push(generateRandomEquipment('high-middle', randomEquipmentSubType())); // Guaranteed high-tier item
-      
-      // 50% chance for second item
+      rewards.push(generateRandomEquipment('high-middle', randomEquipmentSubType()));
       if (Math.random() < 0.5) {
         rewards.push(generateRandomEquipment('high-bottom', randomEquipmentSubType()));
       }
-
       const raidDurationMinutes = 30;
-
       const updatedWorm = {
         ...prev.worm,
         energy: prev.worm.energy - 40,
         xp: newXp,
         level: newLevel,
-        currentActivity: {
-          type: 'raid',
-          endsAt: Date.now() + raidDurationMinutes * 60 * 1000
-        }
+        currentActivity: { type: 'raid', endsAt: Date.now() + raidDurationMinutes * 60 * 1000 }
       };
-
-      const newInventoryItems = rewards.map(item => ({ 
-        itemId: item.id, 
-        quantity: 1, 
-        acquiredAt: Date.now() 
-      }));
-
+      const newInventoryItems = rewards.map(item => ({ itemId: item.id, quantity: 1, acquiredAt: Date.now() }));
       const updatedInventory = [...prev.inventory, ...newInventoryItems];
       const updatedShopItems = [...prev.shopItems, ...rewards];
-
-      toast({
-        title: "Sárkány legyőzve!",
-        description: `${xpGained} XP! Zsákmány: ${rewards.map(r => r.nameHu).join(', ')}${leveledUp ? ` Új szint: ${newLevel}!` : ''}`,
-      });
-
-      return {
-        ...prev,
-        worm: updatedWorm,
-        inventory: updatedInventory,
-        shopItems: updatedShopItems
-      };
+      toast({ title: 'Sárkány legyőzve!', description: `${xpGained} XP! Zsákmány: ${rewards.map(r => r.nameHu).join(', ')}${leveledUp ? ` Új szint: ${newLevel}!` : ''}` });
+      return { ...prev, worm: updatedWorm, inventory: updatedInventory, shopItems: updatedShopItems };
     });
   };
 
   const startAdventure = (): void => {
     if (!gameState.worm) return;
-
     if (gameState.worm.currentActivity && Date.now() < gameState.worm.currentActivity.endsAt) {
-      toast({
-        title: "Már folyamatban van egy tevékenység!",
-        description: "Várd meg, míg az előző befejeződik.",
-        variant: "destructive",
-      });
+      toast({ title: 'Már folyamatban van egy tevékenység!', description: 'Várd meg, míg az előző befejeződik.', variant: 'destructive' });
       return;
     }
-
-    // Check requirements
     if (gameState.worm.level < 8) {
-      toast({
-        title: "Szint túl alacsony", 
-        description: "8. szint szükséges kalandokhoz.",
-        variant: "destructive",
-      });
+      toast({ title: 'Szint túl alacsony', description: '8. szint szükséges kalandokhoz.', variant: 'destructive' });
       return;
     }
-
     if (gameState.worm.energy < 30) {
-      toast({
-        title: "Nincs elég energia",
-        description: "30 energia szükséges.",
-        variant: "destructive",
-      });
+      toast({ title: 'Nincs elég energia', description: '30 energia szükséges.', variant: 'destructive' });
       return;
     }
-
     setGameState(prev => {
       if (!prev.worm) return prev;
-
-      // Adventure rewards (moderate XP, good equipment chance)
       const xpGained = 80;
       const newXp = prev.worm.xp + xpGained;
       const newLevel = calculateLevel(newXp);
       const leveledUp = newLevel > prev.worm.level;
-
-      // 70% chance for equipment
       let rewardItem: Item | null = null;
       if (Math.random() < 0.7) {
         rewardItem = generateRandomEquipment('mid-top', randomEquipmentSubType());
       }
-
       const adventureDurationMinutes = 20;
       const today = new Date().toDateString();
       const counter = prev.worm.dailyCounters['adventure'];
       const count = counter?.date === today ? counter.count : 0;
       const moodChange = 15 - count * 5;
-
       const updatedWorm = {
         ...prev.worm,
         energy: prev.worm.energy - 30,
         xp: newXp,
         level: newLevel,
         mood: Math.max(0, Math.min(100, prev.worm.mood + moodChange)),
-        currentActivity: {
-          type: 'adventure',
-          endsAt: Date.now() + adventureDurationMinutes * 60 * 1000
-        },
-        dailyCounters: {
-          ...prev.worm.dailyCounters,
-          adventure: { date: today, count: count + 1 }
-        }
+        currentActivity: { type: 'adventure', endsAt: Date.now() + adventureDurationMinutes * 60 * 1000 },
+        dailyCounters: { ...prev.worm.dailyCounters, adventure: { date: today, count: count + 1 } }
       };
-
-      const updatedInventory = rewardItem 
-        ? [...prev.inventory, { itemId: rewardItem.id, quantity: 1, acquiredAt: Date.now() }]
-        : prev.inventory;
-
-      const updatedShopItems = rewardItem 
-        ? [...prev.shopItems, rewardItem]
-        : prev.shopItems;
-
-      toast({
-        title: "Kaland befejezve!",
-        description: rewardItem 
-          ? `${xpGained} XP! Találtál: ${rewardItem.nameHu}${leveledUp ? ` Új szint: ${newLevel}!` : ''}`
-          : `${xpGained} XP szerzett!${leveledUp ? ` Új szint: ${newLevel}!` : ''}`,
-      });
-
-      return {
-        ...prev,
-        worm: updatedWorm,
-        inventory: updatedInventory,
-        shopItems: updatedShopItems
-      };
+      const updatedInventory = rewardItem ? [...prev.inventory, { itemId: rewardItem.id, quantity: 1, acquiredAt: Date.now() }] : prev.inventory;
+      const updatedShopItems = rewardItem ? [...prev.shopItems, rewardItem] : prev.shopItems;
+      toast({ title: 'Kaland befejezve!', description: rewardItem ? `${xpGained} XP! Találtál: ${rewardItem.nameHu}${leveledUp ? ` Új szint: ${newLevel}!` : ''}` : `${xpGained} XP szerzett!${leveledUp ? ` Új szint: ${newLevel}!` : ''}` });
+      return { ...prev, worm: updatedWorm, inventory: updatedInventory, shopItems: updatedShopItems };
     });
   };
 
-  // Helper function to calculate level from XP
   const calculateLevel = (xp: number): number => {
     let level = 1;
-    while (xp >= getXpRequiredForLevel(level + 1)) {
-      level++;
-    }
+    while (xp >= getXpRequiredForLevel(level + 1)) level++;
     return level;
   };
 
@@ -1266,20 +436,7 @@ export const useGameData = () => {
     gameState,
     registerUser,
     loginUser,
-    executeTrain,
-    acceptJob,
-    completeJob,
     updateWormProfile,
-    isTrainingAvailable,
-    getTrainingCooldown,
-    buyItem,
-    useItem,
-    equipItem,
-    unequipItem,
-    sellItemToShop,
-    listItemForSale,
-    buyListing,
-    getTotalStats,
     isTourAvailable,
     getTourCooldown,
     startTour,
@@ -1287,6 +444,28 @@ export const useGameData = () => {
     startRaid,
     startAdventure,
     isLoggedIn: !!gameState.user && !!gameState.worm,
-    logout
+    logout,
+    ...training,
+    ...jobs,
+    ...inventory,
+    ...market
   };
 };
+type GameContextValue = ReturnType<typeof useGameDataInternal>;
+
+const GameContext = createContext<GameContextValue | null>(null);
+
+export const GameProvider = ({ children }: { children: ReactNode }) => {
+  const value = useGameDataInternal();
+  return createElement(GameContext.Provider, { value }, children);
+};
+
+export const useGameData = () => {
+  const context = useContext(GameContext);
+  if (!context) {
+    throw new Error('useGameData must be used within a GameProvider');
+  }
+  return context;
+};
+
+export type GameHook = GameContextValue;

--- a/src/hooks/useInventory.ts
+++ b/src/hooks/useInventory.ts
@@ -1,0 +1,266 @@
+import { GameState, Worm, Item } from '../types/game';
+
+export const useInventory = (
+  gameState: GameState,
+  setGameState: React.Dispatch<React.SetStateAction<GameState>>,
+  toast: (opts: { title: string; description: string; variant?: string }) => void
+) => {
+  // Buy item from shop
+  const buyItem = (itemId: string) => {
+    const item = gameState.shopItems.find(i => i.id === itemId);
+    if (!item || !gameState.worm) return;
+
+    const worm = gameState.worm;
+
+    // Check if player has enough coins
+    if (worm.coins < item.price) {
+      toast({
+        title: 'Nincs elég érme!',
+        description: `${item.nameHu} ${item.price} érmét igényel.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check level requirement for equipment
+    if (item.level && worm.level < item.level) {
+      toast({
+        title: 'Túl alacsony szint!',
+        description: `${item.nameHu} ${item.level}. szintet igényel.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Add to inventory
+    const existingItem = gameState.inventory.find(inv => inv.itemId === itemId);
+    const updatedInventory = existingItem
+      ? gameState.inventory.map(inv =>
+          inv.itemId === itemId
+            ? { ...inv, quantity: inv.quantity + 1 }
+            : inv
+        )
+      : [...gameState.inventory, { itemId, quantity: 1, acquiredAt: Date.now() }];
+
+    // Deduct coins
+    const updatedWorm: Worm = {
+      ...worm,
+      coins: worm.coins - item.price,
+      lastUpdated: Date.now()
+    };
+
+    setGameState(prev => ({
+      ...prev,
+      worm: updatedWorm,
+      inventory: updatedInventory
+    }));
+
+    toast({
+      title: 'Vásárlás sikeres!',
+      description: `${item.nameHu} hozzáadva a táskádhoz.`
+    });
+  };
+
+  // Use consumable item
+  const useItem = (itemId: string) => {
+    const inventoryItem = gameState.inventory.find(inv => inv.itemId === itemId);
+    const item = gameState.shopItems.find(i => i.id === itemId);
+
+    if (!inventoryItem || !item || !gameState.worm || inventoryItem.quantity <= 0) return;
+
+    if (item.type !== 'consumable') {
+      toast({
+        title: 'Nem használható!',
+        description: 'Ez a tárgy nem használható fel.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    const worm = gameState.worm;
+    const effects = item.effects || {};
+
+    // Apply effects
+    const updatedWorm: Worm = {
+      ...worm,
+      energy: Math.min(100, worm.energy + (effects.energy || 0)),
+      health: Math.min(100, worm.health + (effects.health || 0)),
+      mood: Math.min(100, worm.mood + (effects.mood || 0)),
+      strength: worm.strength + (effects.strength || 0),
+      dexterity: worm.dexterity + (effects.dexterity || 0),
+      endurance: worm.endurance + (effects.endurance || 0),
+      stamina: worm.stamina + (effects.stamina || 0),
+      intelligence: worm.intelligence + (effects.intelligence || 0),
+      charisma: worm.charisma + (effects.charisma || 0),
+      lastUpdated: Date.now()
+    };
+
+    // Remove one from inventory
+    const updatedInventory = inventoryItem.quantity === 1
+      ? gameState.inventory.filter(inv => inv.itemId !== itemId)
+      : gameState.inventory.map(inv =>
+          inv.itemId === itemId
+            ? { ...inv, quantity: inv.quantity - 1 }
+            : inv
+        );
+
+    setGameState(prev => ({
+      ...prev,
+      worm: updatedWorm,
+      inventory: updatedInventory
+    }));
+
+    toast({
+      title: 'Tárgy használva!',
+      description: `${item.nameHu} hatása alkalmazva.`
+    });
+  };
+
+  // Equip item
+  const equipItem = (itemId: string) => {
+    const inventoryItem = gameState.inventory.find(inv => inv.itemId === itemId);
+    const item = gameState.shopItems.find(i => i.id === itemId);
+
+    if (!inventoryItem || !item || !gameState.worm || item.type !== 'equipment') return;
+
+    const worm = gameState.worm;
+    const slot = item.subType as keyof typeof worm.equipment;
+
+    if (!slot || !['helmet', 'armor', 'weapon', 'accessory'].includes(slot)) {
+      toast({
+        title: 'Hiba!',
+        description: 'Ismeretlen felszerelés típus.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check level requirement
+    if (item.level && worm.level < item.level) {
+      toast({
+        title: 'Túl alacsony szint!',
+        description: `${item.nameHu} ${item.level}. szintet igényel.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    const updatedWorm: Worm = {
+      ...worm,
+      equipment: {
+        ...worm.equipment,
+        [slot]: itemId
+      },
+      lastUpdated: Date.now()
+    };
+
+    setGameState(prev => ({
+      ...prev,
+      worm: updatedWorm
+    }));
+
+    toast({
+      title: 'Felszerelés felöltve!',
+      description: `${item.nameHu} sikeresen felöltve.`
+    });
+  };
+
+  // Unequip item
+  const unequipItem = (slot: keyof Worm['equipment']) => {
+    if (!gameState.worm) return;
+
+    const updatedWorm: Worm = {
+      ...gameState.worm,
+      equipment: {
+        ...gameState.worm.equipment,
+        [slot]: undefined
+      },
+      lastUpdated: Date.now()
+    };
+
+    setGameState(prev => ({
+      ...prev,
+      worm: updatedWorm
+    }));
+
+    toast({
+      title: 'Felszerelés levéve!',
+      description: 'Tárgy sikeresen levéve.'
+    });
+  };
+
+  const sellItemToShop = (itemId: string) => {
+    const inventoryItem = gameState.inventory.find(inv => inv.itemId === itemId);
+    const item = gameState.shopItems.find(i => i.id === itemId);
+    if (!inventoryItem || !item || !gameState.worm) return;
+
+    const ranges: Record<Item['rarity'], [number, number]> = {
+      common: [30, 50],
+      rare: [50, 75],
+      epic: [75, 90],
+      legendary: [90, 100],
+    };
+    const [min, max] = ranges[item.rarity];
+    const price = Math.floor(Math.random() * (max - min + 1)) + min;
+
+    const updatedInventory = inventoryItem.quantity === 1
+      ? gameState.inventory.filter(inv => inv.itemId !== itemId)
+      : gameState.inventory.map(inv =>
+          inv.itemId === itemId ? { ...inv, quantity: inv.quantity - 1 } : inv
+        );
+
+    const updatedWorm: Worm = {
+      ...gameState.worm,
+      coins: gameState.worm.coins + price,
+      lastUpdated: Date.now(),
+    };
+
+    setGameState(prev => ({
+      ...prev,
+      worm: updatedWorm,
+      inventory: updatedInventory,
+    }));
+
+    toast({ title: 'Eladva!', description: `${item.nameHu} eladva ${price} érméért.` });
+  };
+
+  // Get total stats including equipment bonuses
+  const getTotalStats = (worm: Worm) => {
+    const totalStats = {
+      strength: worm.strength,
+      dexterity: worm.dexterity,
+      endurance: worm.endurance,
+      stamina: worm.stamina,
+      intelligence: worm.intelligence,
+      charisma: worm.charisma
+    };
+
+    // Add equipment bonuses
+    Object.values(worm.equipment).forEach(itemId => {
+      if (itemId) {
+        const item = gameState.shopItems.find(i => i.id === itemId);
+        if (item?.statBonus) {
+          totalStats.strength += item.statBonus.strength || 0;
+          totalStats.dexterity += item.statBonus.dexterity || 0;
+          totalStats.endurance += item.statBonus.endurance || 0;
+          totalStats.stamina += item.statBonus.stamina || 0;
+          totalStats.intelligence += item.statBonus.intelligence || 0;
+          totalStats.charisma += item.statBonus.charisma || 0;
+        }
+      }
+    });
+
+    return totalStats;
+  };
+
+  return {
+    buyItem,
+    useItem,
+    equipItem,
+    unequipItem,
+    sellItemToShop,
+    getTotalStats
+  };
+};
+
+export type InventoryHook = ReturnType<typeof useInventory>;

--- a/src/hooks/useJobs.ts
+++ b/src/hooks/useJobs.ts
@@ -1,0 +1,187 @@
+import { GameState, Worm, JobAssignment, getXpRequiredForLevel, DAILY_JOB_LIMIT } from '../types/game';
+
+export const useJobs = (
+  gameState: GameState,
+  setGameState: React.Dispatch<React.SetStateAction<GameState>>,
+  toast: (opts: { title: string; description: string; variant?: string }) => void
+) => {
+  // Accept a job
+  const acceptJob = (jobId: string) => {
+    const job = gameState.jobs.find(j => j.id === jobId);
+    if (!job || !gameState.worm) return;
+
+    const worm = gameState.worm;
+
+    // Prevent action if another activity is running
+    if (worm.currentActivity && Date.now() < worm.currentActivity.endsAt) {
+      toast({
+        title: 'Már folyamatban van egy tevékenység!',
+        description: 'Várd meg, míg az előző befejeződik.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check daily job limit
+    const today = new Date().toDateString();
+    const todayAssignments = gameState.jobAssignments.filter(ja =>
+      new Date(ja.startedAt).toDateString() === today
+    );
+
+    if (todayAssignments.length >= DAILY_JOB_LIMIT) {
+      toast({
+        title: 'Napi limit elérve!',
+        description: `Ma már ${DAILY_JOB_LIMIT} munkát végeztél el.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check level requirement
+    if (worm.level < job.minLevel) {
+      toast({
+        title: 'Túl alacsony szint!',
+        description: `${job.nameHu} ${job.minLevel}. szintet igényel.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check energy
+    if (worm.energy < job.energyCost) {
+      toast({
+        title: 'Nincs elég energia!',
+        description: `${job.nameHu} ${job.energyCost} energiát igényel.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check stat requirements
+    for (const [stat, required] of Object.entries(job.statRequirements)) {
+      const statValue = worm[stat as keyof Pick<Worm, 'strength' | 'dexterity' | 'endurance' | 'stamina' | 'intelligence' | 'charisma'>] as number;
+      if (statValue < (required as number)) {
+        const statName = stat === 'strength' ? 'Erő' :
+          stat === 'dexterity' ? 'Ügyesség' :
+          stat === 'endurance' ? 'Kitartás' :
+          stat === 'stamina' ? 'Állóképesség' :
+          stat === 'intelligence' ? 'Intelligencia' : 'Karizma';
+        toast({
+          title: 'Nem elég magas stat!',
+          description: `${job.nameHu} ${required} ${statName}-t igényel.`,
+          variant: 'destructive'
+        });
+        return;
+      }
+    }
+
+    // Create job assignment
+    const assignment: JobAssignment = {
+      id: Date.now().toString(),
+      jobId,
+      status: 'accepted',
+      startedAt: Date.now(),
+    };
+
+    // Daily counter for mood penalty
+    const jobCounter = worm.dailyCounters[`job_${jobId}`];
+    const jobCount = jobCounter?.date === today ? jobCounter.count : 0;
+    const moodPenalty = 5 + jobCount * 2;
+
+    // Deduct energy immediately and apply mood change
+    const updatedWorm: Worm = {
+      ...worm,
+      energy: worm.energy - job.energyCost,
+      mood: Math.max(0, worm.mood - moodPenalty),
+      currentActivity: {
+        type: 'job',
+        endsAt: Date.now() + job.durationMinutes * 60 * 1000
+      },
+      dailyCounters: {
+        ...worm.dailyCounters,
+        [`job_${jobId}`]: { date: today, count: jobCount + 1 }
+      },
+      lastUpdated: Date.now()
+    };
+
+    setGameState(prev => ({
+      ...prev,
+      worm: updatedWorm,
+      jobAssignments: [...prev.jobAssignments, assignment]
+    }));
+
+    toast({
+      title: 'Munka elfogadva!',
+      description: `${job.nameHu} - ${job.durationMinutes} perc múlva fejezheted be.`
+    });
+  };
+
+  // Complete a job
+  const completeJob = (assignmentId: string) => {
+    const assignment = gameState.jobAssignments.find(ja => ja.id === assignmentId);
+    const job = assignment ? gameState.jobs.find(j => j.id === assignment.jobId) : null;
+
+    if (!assignment || !job || !gameState.worm || assignment.status !== 'accepted') return;
+
+    // Check if enough time has passed
+    const timeElapsed = Date.now() - assignment.startedAt;
+    const requiredTime = job.durationMinutes * 60 * 1000;
+
+    if (timeElapsed < requiredTime) {
+      const remainingMinutes = Math.ceil((requiredTime - timeElapsed) / (60 * 1000));
+      toast({
+        title: 'Még nem fejezhető be!',
+        description: `${remainingMinutes} perc van hátra.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    const worm = gameState.worm;
+
+    // Update worm with rewards
+    const updatedWorm: Worm = {
+      ...worm,
+      coins: worm.coins + job.rewardCoins,
+      xp: worm.xp + job.rewardXp,
+      currentActivity: undefined,
+      lastUpdated: Date.now()
+    };
+
+    // Check for level up
+    let newLevel = updatedWorm.level;
+    while (updatedWorm.xp >= getXpRequiredForLevel(newLevel + 1)) {
+      newLevel++;
+    }
+
+    if (newLevel > updatedWorm.level) {
+      updatedWorm.level = newLevel;
+      toast({
+        title: 'Szint lépés! 🎉',
+        description: `${worm.name} elérte a ${newLevel}. szintet!`
+      });
+    }
+
+    // Update assignment status
+    const updatedAssignments = gameState.jobAssignments.map(ja =>
+      ja.id === assignmentId
+        ? { ...ja, status: 'completed' as const, completedAt: Date.now() }
+        : ja
+    );
+
+    setGameState(prev => ({
+      ...prev,
+      worm: updatedWorm,
+      jobAssignments: updatedAssignments
+    }));
+
+    toast({
+      title: 'Munka befejezve! 💰',
+      description: `+${job.rewardCoins} érme, +${job.rewardXp} XP`
+    });
+  };
+
+  return { acceptJob, completeJob };
+};
+
+export type JobsHook = ReturnType<typeof useJobs>;

--- a/src/hooks/useMarket.ts
+++ b/src/hooks/useMarket.ts
@@ -1,0 +1,103 @@
+import { useCallback, useEffect } from 'react';
+import { GameState, Worm, Item } from '../types/game';
+
+export const useMarket = (
+  gameState: GameState,
+  setGameState: React.Dispatch<React.SetStateAction<GameState>>,
+  toast: (opts: { title: string; description: string; variant?: string }) => void
+) => {
+  const fetchMarketListings = useCallback(async () => {
+    try {
+      const res = await fetch('/api/market');
+      if (!res.ok) return;
+      const data = await res.json();
+      setGameState(prev => ({ ...prev, marketListings: data.listings || [] }));
+    } catch (err) {
+      console.error('Failed to fetch market', err);
+    }
+  }, [setGameState]);
+
+  useEffect(() => {
+    void fetchMarketListings();
+  }, [fetchMarketListings]);
+
+  const listItemForSale = async (itemId: string, price: number) => {
+    const inventoryItem = gameState.inventory.find(inv => inv.itemId === itemId);
+    const item = gameState.shopItems.find(i => i.id === itemId);
+    if (!inventoryItem || !item || !gameState.user) return;
+
+    const updatedInventory = inventoryItem.quantity === 1
+      ? gameState.inventory.filter(inv => inv.itemId !== itemId)
+      : gameState.inventory.map(inv =>
+          inv.itemId === itemId ? { ...inv, quantity: inv.quantity - 1 } : inv
+        );
+
+    try {
+      const res = await fetch('/api/market/list', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ itemId, price, seller: gameState.user.username }),
+      });
+      if (!res.ok) throw new Error('Failed to list');
+      const data = await res.json();
+      const listing = data.listing;
+      setGameState(prev => ({
+        ...prev,
+        inventory: updatedInventory,
+        marketListings: [...prev.marketListings, listing],
+      }));
+      toast({ title: 'Piacra téve!', description: `${item.nameHu} listázva ${price} érméért.` });
+    } catch (err) {
+      console.error('Failed to list item', err);
+      toast({ title: 'Hiba', description: 'Nem sikerült feltölteni a piacra.', variant: 'destructive' });
+    }
+  };
+
+  const buyListing = async (listingId: string) => {
+    const listing = gameState.marketListings.find(l => l.id === listingId);
+    if (!listing || !gameState.worm) return;
+    if (listing.price > gameState.worm.coins) {
+      toast({ title: 'Nincs elég érme!', description: 'Nem tudod megvenni ezt a tárgyat.', variant: 'destructive' });
+      return;
+    }
+
+    const item = gameState.shopItems.find(i => i.id === listing.itemId);
+    if (!item) return;
+
+    const existingItem = gameState.inventory.find(inv => inv.itemId === listing.itemId);
+    const updatedInventory = existingItem
+      ? gameState.inventory.map(inv =>
+          inv.itemId === listing.itemId ? { ...inv, quantity: inv.quantity + 1 } : inv
+        )
+      : [...gameState.inventory, { itemId: listing.itemId, quantity: 1, acquiredAt: Date.now() }];
+
+    const updatedWorm: Worm = {
+      ...gameState.worm,
+      coins: gameState.worm.coins - listing.price,
+      lastUpdated: Date.now(),
+    };
+
+    try {
+      const res = await fetch('/api/market/remove', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ listingId }),
+      });
+      if (!res.ok) throw new Error('Failed to remove');
+      setGameState(prev => ({
+        ...prev,
+        worm: updatedWorm,
+        inventory: updatedInventory,
+        marketListings: prev.marketListings.filter(l => l.id !== listingId),
+      }));
+      toast({ title: 'Vásárlás sikeres!', description: `${item.nameHu} megvásárolva.` });
+    } catch (err) {
+      console.error('Failed to buy listing', err);
+      toast({ title: 'Hiba', description: 'Nem sikerült megvásárolni a tárgyat.', variant: 'destructive' });
+    }
+  };
+
+  return { listItemForSale, buyListing };
+};
+
+export type MarketHook = ReturnType<typeof useMarket>;

--- a/src/hooks/useTraining.ts
+++ b/src/hooks/useTraining.ts
@@ -1,0 +1,136 @@
+import { GameState, Worm, getXpRequiredForLevel, getDiminishingMultiplier } from '../types/game';
+
+export const useTraining = (
+  gameState: GameState,
+  setGameState: React.Dispatch<React.SetStateAction<GameState>>,
+  toast: (opts: { title: string; description: string; variant?: string }) => void
+) => {
+  // Check if training is available (not on cooldown)
+  const isTrainingAvailable = (trainingId: string): boolean => {
+    if (!gameState.worm) return false;
+    const cooldownEnd = gameState.worm.cooldowns[trainingId];
+    return !cooldownEnd || Date.now() >= cooldownEnd;
+  };
+
+  // Get remaining cooldown time in seconds
+  const getTrainingCooldown = (trainingId: string): number => {
+    if (!gameState.worm) return 0;
+    const cooldownEnd = gameState.worm.cooldowns[trainingId];
+    if (!cooldownEnd) return 0;
+    return Math.max(0, Math.ceil((cooldownEnd - Date.now()) / 1000));
+  };
+
+  // Execute training
+  const executeTrain = (trainingId: string) => {
+    const training = gameState.trainings.find(t => t.id === trainingId);
+    if (!training || !gameState.worm) return;
+
+    const worm = gameState.worm;
+
+    // Prevent action if another activity is running
+    if (worm.currentActivity && Date.now() < worm.currentActivity.endsAt) {
+      toast({
+        title: 'Már folyamatban van egy tevékenység!',
+        description: 'Várd meg, míg az előző befejeződik.',
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check energy
+    if (worm.energy < training.energyCost) {
+      toast({
+        title: 'Nincs elég energia!',
+        description: `${training.nameHu} ${training.energyCost} energiát igényel.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check coins
+    if (training.coinCost && worm.coins < training.coinCost) {
+      toast({
+        title: 'Nincs elég érme!',
+        description: `${training.nameHu} ${training.coinCost} érmét igényel.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Check cooldown
+    if (!isTrainingAvailable(trainingId)) {
+      const remaining = getTrainingCooldown(trainingId);
+      toast({
+        title: 'Még várnod kell!',
+        description: `${training.nameHu} még ${Math.ceil(remaining / 60)} perc múlva lesz elérhető.`,
+        variant: 'destructive'
+      });
+      return;
+    }
+
+    // Get daily counter for diminishing returns
+    const today = new Date().toDateString();
+    const dailyCounter = worm.dailyCounters[trainingId];
+    const todayCount = (dailyCounter?.date === today) ? dailyCounter.count : 0;
+    const multiplier = getDiminishingMultiplier(todayCount);
+
+    // Calculate gains with diminishing returns
+    const actualStatGain = Math.floor(training.statGain * multiplier);
+    const actualXpGain = Math.floor(training.xpGain * multiplier);
+
+    // Mood penalty increases with repeated trainings
+    const moodPenalty = 5 + todayCount * 2;
+
+    // Update worm
+    const updatedWorm: Worm = {
+      ...worm,
+      energy: worm.energy - training.energyCost,
+      coins: worm.coins - (training.coinCost || 0),
+      xp: worm.xp + actualXpGain,
+      mood: Math.max(0, worm.mood - moodPenalty),
+      [training.statFocus]: worm[training.statFocus] + actualStatGain,
+      cooldowns: {
+        ...worm.cooldowns,
+        [trainingId]: Date.now() + training.cooldownSeconds * 1000
+      },
+      dailyCounters: {
+        ...worm.dailyCounters,
+        [trainingId]: { date: today, count: todayCount + 1 }
+      },
+      currentActivity: {
+        type: 'training',
+        endsAt: Date.now() + training.cooldownSeconds * 1000
+      },
+      lastUpdated: Date.now()
+    };
+
+    // Check for level up
+    let newLevel = updatedWorm.level;
+    while (updatedWorm.xp >= getXpRequiredForLevel(newLevel + 1)) {
+      newLevel++;
+    }
+
+    if (newLevel > updatedWorm.level) {
+      updatedWorm.level = newLevel;
+      toast({
+        title: 'Szint lépés! 🎉',
+        description: `${worm.name} elérte a ${newLevel}. szintet!`
+      });
+    }
+
+    setGameState(prev => ({ ...prev, worm: updatedWorm }));
+
+    toast({
+      title: 'Edzés befejezve!',
+      description: `+${actualStatGain} ${training.statFocus === 'strength' ? 'Erő' :
+        training.statFocus === 'dexterity' ? 'Ügyesség' :
+        training.statFocus === 'endurance' ? 'Kitartás' :
+        training.statFocus === 'stamina' ? 'Állóképesség' :
+        training.statFocus === 'intelligence' ? 'Intelligencia' : 'Karizma'}, +${actualXpGain} XP`
+    });
+  };
+
+  return { isTrainingAvailable, getTrainingCooldown, executeTrain };
+};
+
+export type TrainingHook = ReturnType<typeof useTraining>;


### PR DESCRIPTION
## Summary
- split monolithic game data hook into domain hooks for training, jobs, inventory and market
- add aggregated useGame hook to compose domain hooks and manage game state
- update pages to consume the new useGame hook
- provide GameProvider context to share game state across the app
- rename useGame hook to useGameData and update imports to resolve merge conflict
- keep useGameData as a .ts module without JSX to avoid future merge issues

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b76da6420483229fcd186fd6a18b29